### PR TITLE
fix: Disable user-scheduler in juypter helm-chart

### DIFF
--- a/stacks/_templates/jupyterhub.yaml
+++ b/stacks/_templates/jupyterhub.yaml
@@ -17,13 +17,16 @@ options:
   proxy:
     service:
       type: NodePort
+  rbac:
+    create: true
   prePuller:
     hook:
       enabled: false
     continuous:
       enabled: false
-  rbac:
-    create: true
+  scheduling:
+    userScheduler:
+      enabled: false
   singleuser:
     # `cmd: null` allows the custom CMD of the Jupyter docker-stacks to be used
     # which performs further customization on startup.

--- a/stacks/_templates/jupyterhub.yaml
+++ b/stacks/_templates/jupyterhub.yaml
@@ -3,7 +3,7 @@ name: jupyterhub
 repo:
   name: jupyterhub
   url: https://jupyterhub.github.io/helm-chart/
-version: 2.0.0
+version: 3.0.0
 options:
   hub:
     config:


### PR DESCRIPTION
Jupyter helm-chart < 3.0.0 has the bug https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3128 and does not run on k8s 1.27
