### PR TITLE
fix: Increase memory for Druid middlemanager in nifi-kafka-druid-superset-s3

### DIFF
--- a/demos/demos-v2.yaml
+++ b/demos/demos-v2.yaml
@@ -50,7 +50,7 @@ demos:
     supportedNamespaces: ["default"]
     resourceRequests:
       cpu: 8700m
-      memory: 27746Mi
+      memory: 29746Mi
       pvc: 75Gi # 30Gi for Kafka
   nifi-kafka-druid-water-level-data:
     description:  Demo ingesting water level data into Kafka using NiFi, streaming it into Druid and creating a Superset dashboard
@@ -71,7 +71,7 @@ demos:
     supportedNamespaces: ["default"]
     resourceRequests:
       cpu: 8900m
-      memory: 28042Mi
+      memory: 30042Mi
       pvc: 75Gi # 30Gi for Kafka
   spark-k8s-anomaly-detection-taxi-data:
     description: Demo loading New York taxi data into an S3 bucket and carrying out an anomaly detection analysis on it

--- a/docs/modules/demos/pages/nifi-kafka-druid-earthquake-data.adoc
+++ b/docs/modules/demos/pages/nifi-kafka-druid-earthquake-data.adoc
@@ -42,7 +42,7 @@ image::nifi-kafka-druid-earthquake-data/overview.png[]
 To run this demo, your system needs at least:
 
 * 9 {k8s-cpu}[cpu units] (core/hyperthread)
-* 28GiB memory
+* 30GiB memory
 * 75GiB disk storage
 
 == Listing Deployed Stacklets

--- a/docs/modules/demos/pages/nifi-kafka-druid-water-level-data.adoc
+++ b/docs/modules/demos/pages/nifi-kafka-druid-water-level-data.adoc
@@ -47,7 +47,7 @@ image::nifi-kafka-druid-water-level-data/overview.png[]
 To run this demo, your system needs at least:
 
 * 9 {k8s-cpu}[cpu units] (core/hyperthread)
-* 28GiB memory
+* 30GiB memory
 * 75GiB disk storage
 
 == List Deployed Stacklets

--- a/stacks/nifi-kafka-druid-superset-s3/druid.yaml
+++ b/stacks/nifi-kafka-druid-superset-s3/druid.yaml
@@ -62,7 +62,7 @@ spec:
               min: "1"
               max: "4" # Need enough CPU cores to run multiple ingestion jobs at once
             memory:
-              limit: 2Gi
+              limit: 4Gi
   routers:
     roleGroups:
       default:

--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -189,7 +189,7 @@ stacks:
     supportedNamespaces: []
     resourceRequests:
       cpu: 8900m
-      memory: 28042Mi
+      memory: 30042Mi
       pvc: 75Gi
     parameters:
       - name: nifiAdminPassword


### PR DESCRIPTION
Previously it OOMed