### PR TITLE
demo: hbase-hdfs-load-cycling-data

### DIFF
--- a/docs/modules/demos/pages/hbase-hdfs-load-cycling-data.adoc
+++ b/docs/modules/demos/pages/hbase-hdfs-load-cycling-data.adoc
@@ -33,6 +33,13 @@ To run this demo, your system needs at least:
 * 6GiB memory
 * 16GiB disk storage
 
+== Installing the Demo
+
+[source]
+----
+stackablectl demo install hbase-hdfs-load-cycling-data
+----
+
 == Listing Deployed Stacklets
 
 To list the installed Stackable services run the following command: `stackablectl stacklet list`
@@ -68,7 +75,11 @@ PRODUCT    NAME       NAMESPACE  ENDPOINTS                                      
 
 include::partial$instance-hint.adoc[]
 
-== Adding the First Job
+== Loading data
+
+This demo will run two jobs to automatically load data.
+
+=== distcp-cycling-data
 
 {distcp}[DistCp] (distributed copy) is used for large inter/intra-cluster copying. It uses MapReduce to effect its
 distribution, error handling, recovery, and reporting. It expands a list of files and directories into input to map
@@ -90,7 +101,7 @@ Copying s3a://public-backup-nyc-tlc/cycling-tripdata/demo-cycling-tripdata.csv.g
 [LocalJobRunner Map Task Executor #0] mapred.LocalJobRunner (LocalJobRunner.java:statusUpdate(634)) - 100.0% Copying s3a://public-backup-nyc-tlc/cycling-tripdata/demo-cycling-tripdata.csv.gz to hdfs://hdfs/data/raw/demo-cycling-tripdata.csv.gz
 ----
 
-== Adding the Second Job
+=== create-hfile-and-import-to-hbase
 
 The second Job consists of 2 steps.
 
@@ -105,7 +116,12 @@ the shell via:
 kubectl exec -it hbase-master-default-0 -- bin/hbase shell
 ----
 
-If you use k9s, you can drill into the `hbase-master-default-0` pod and execute `bin/hbase shell list`.
+NOTE: If you use k9s, you can drill into the `hbase-master-default-0` pod and execute `bin/hbase shell`.
+
+[source]
+----
+list
+----
 
 [source]
 ----
@@ -114,8 +130,16 @@ cycling-tripdata
 ----
 
 Secondly, we'll use `org.apache.hadoop.hbase.tool.LoadIncrementalHFiles` (see {bulkload}[bulk load docs]) to import
-the Hfiles into the table and ingest rows. You can now use the hbase shell again and execute `count 'cycling-tripdata'`.
-Ssee below for a partial result:
+the Hfiles into the table and ingest rows. 
+
+Now we will see how many rows are in the `cycling-tripdata` table:
+
+[source]
+----
+count 'cycling-tripdata'
+----
+
+See below for a partial result:
 
 [source]
 ----
@@ -133,12 +157,17 @@ Took 13.4666 seconds
 
 == Inspecting the Table
 
-You can now use the table and the data. You can use all available hbase shell commands. Below, you'll see the table
-description.
+You can now use the table and the data. You can use all available hbase shell commands.
+
+[source]
+----
+describe 'cycling-tripdata'
+----
+
+Below, you'll see the table description.
 
 [source,console]
 ----
-describe 'cycling-tripdata'
 Table cycling-tripdata is ENABLED
 cycling-tripdata
 COLUMN FAMILIES DESCRIPTION
@@ -158,8 +187,13 @@ COLUMN FAMILIES DESCRIPTION
 
 == Accessing the Hbase Web Interface
 
-The Hbase web UI will give you information on the status and metrics of your Hbase cluster. If the UI is unavailable
-please do a port-forward `kubectl port-forward hbase-master-default-0 16010`. See below for the start page.
+[TIP]
+====
+Run `stackablectl stacklet list` to get the address of the _ui-http_ endpoint.
+If the UI is unavailable, please do a port-forward `kubectl port-forward hbase-master-default-0 16010`.
+====
+
+The Hbase web UI will give you information on the status and metrics of your Hbase cluster. See below for the start page.
 
 image::hbase-hdfs-load-cycling-data/hbase-ui-start-page.png[]
 

--- a/stacks/hdfs-hbase/hdfs.yaml
+++ b/stacks/hdfs-hbase/hdfs.yaml
@@ -7,10 +7,10 @@ spec:
     productVersion: 3.3.6
   clusterConfig:
     dfsReplication: 1
-    listenerClass: external-unstable
     zookeeperConfigMapName: hdfs-znode
   nameNodes:
     config:
+      listenerClass: external-stable
       resources:
         storage:
           data:
@@ -20,6 +20,7 @@ spec:
         replicas: 2
   dataNodes:
     config:
+      listenerClass: external-unstable
       resources:
         storage:
           data:

--- a/stacks/hdfs-hbase/zookeeper.yaml
+++ b/stacks/hdfs-hbase/zookeeper.yaml
@@ -5,7 +5,7 @@ metadata:
   name: zookeeper
 spec:
   image:
-    productVersion: 3.8.3
+    productVersion: 3.9.1
   servers:
     roleGroups:
       default:

--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -143,6 +143,7 @@ stacks:
     stackableOperators:
       - commons
       - secret
+      - listener
       - zookeeper
       - hdfs
       - hbase


### PR DESCRIPTION
- hdfs-hbase stack
  - update zookeeper
  - add listener operator 
  - fix listenerClass placement
- hbase-hdfs-load-cycling-data demo
  - docs: improve readability
  - If https://github.com/stackabletech/stackable-cockpit/pull/213 isn't fixed in time, we will need a note about the missing endpoints when running `stacklet list`.