### PR TITLE
Added listener operator to all the stacks that are using HDFS

### DIFF
--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -328,6 +328,7 @@ stacks:
     stackableOperators:
       - commons
       - secret
+      - listener
       - zookeeper
       - hdfs
       - spark-k8s
@@ -357,6 +358,7 @@ stacks:
     stackableOperators:
       - commons
       - secret
+      - listener
       - zookeeper
       - hdfs
       - hive
@@ -440,6 +442,7 @@ stacks:
     stackableOperators:
       - commons
       - secret
+      - listener
       - trino
       - superset
       - zookeeper


### PR DESCRIPTION
The listener operator is required for HDFS so I added it to all of the stacks that use HDFS but did not install it.