### PR TITLE
Keycloak opa poc fix

### DIFF
--- a/stacks/keycloak-opa-poc/setup-keycloak.yaml
+++ b/stacks/keycloak-opa-poc/setup-keycloak.yaml
@@ -69,7 +69,7 @@ spec:
           - |
             echo "Download keycloak"
             curl -LO https://github.com/keycloak/keycloak/releases/download/23.0.0/keycloak-23.0.0.zip
-            unzip keycloak-23.0.0.zip
+            unzip -o keycloak-23.0.0.zip
             cd keycloak-23.0.0/bin
             ./kcadm.sh config credentials --config kcadm.conf --server http://keycloak:8080/ --realm master --user admin --password "$KEYCLOAK_ADMIN_PASSWORD"
             ./kcadm.sh create users --config kcadm.conf -s username=alice -s enabled=true || true

--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -328,6 +328,7 @@ stacks:
     stackableOperators:
       - commons
       - secret
+      - listener
       - zookeeper
       - hdfs
       - spark-k8s
@@ -357,6 +358,7 @@ stacks:
     stackableOperators:
       - commons
       - secret
+      - listener
       - zookeeper
       - hdfs
       - hive
@@ -440,6 +442,7 @@ stacks:
     stackableOperators:
       - commons
       - secret
+      - listener
       - trino
       - superset
       - zookeeper


### PR DESCRIPTION
If the setup-keycloak job fails the first time it is run it will fail on all subsequent attempts. This is because it will download and unpack the keycloak zip file each time, but on subsequent attempts fails when unzip prompts for user input before overwriting files. Added the -o flag to unzip to force overwriting of existing files.