### PR TITLE
fix: fix url typo for pegelonline

### DIFF
--- a/docs/modules/demos/pages/nifi-kafka-druid-water-level-data.adoc
+++ b/docs/modules/demos/pages/nifi-kafka-druid-water-level-data.adoc
@@ -5,7 +5,7 @@
 :druid-tutorial: https://druid.apache.org/docs/latest/tutorials/tutorial-kafka.html#loading-data-with-the-data-loader
 :k8s-cpu: https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#cpu
 :pegelonline-rest: https://www.pegelonline.wsv.de/webservice/dokuRestapi
-:pegelonline: https://www.pegelonline.wsv.de/webservice/ueberblic
+:pegelonline: https://www.pegelonline.wsv.de/webservice/ueberblick
 :kcat: https://github.com/edenhill/kcat
 
 Install this demo on an existing Kubernetes cluster:


### PR DESCRIPTION
Just a small fix to a typo in a url for the pegelonline website.