### PR TITLE
Add listener-operator to every stack

### DIFF
--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -4,6 +4,7 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
      - commons
+     - listener
     labels:
       - monitoring
       - prometheus
@@ -26,6 +27,7 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
+      - listener
       - secret
       - zookeeper # demo does install a zookeeper to produce logs
     labels:
@@ -60,6 +62,7 @@ stacks:
     stackableRelease: dev
     stackableOperators:
       - commons
+      - listener
       - secret
     labels:
       - jaeger
@@ -84,6 +87,7 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
+      - listener
       - secret
       - airflow
       - spark-k8s # Some demo does schedule a Spark job
@@ -110,6 +114,7 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
+      - listener
       - secret
       - hive
       - trino
@@ -166,8 +171,8 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
-      - secret
       - listener
+      - secret
       - zookeeper
       - hdfs
       - hbase
@@ -189,6 +194,7 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
+      - listener
       - secret
       - zookeeper
       - kafka
@@ -234,6 +240,7 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
+      - listener
       - secret
       - hive
       - trino
@@ -278,6 +285,7 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
+      - listener
       - secret
       - hive
       - trino
@@ -319,6 +327,7 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
+      - listener
       - secret
       - hive
       - trino
@@ -352,8 +361,8 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
-      - secret
       - listener
+      - secret
       - zookeeper
       - hdfs
       - spark-k8s
@@ -382,8 +391,8 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
-      - secret
       - listener
+      - secret
       - zookeeper
       - hdfs
       - hive
@@ -419,6 +428,7 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
+      - listener
       - secret
     labels:
       - authentication
@@ -441,6 +451,7 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
+      - listener
       - secret
     labels:
       - authentication
@@ -466,8 +477,8 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
-      - secret
       - listener
+      - secret
       - trino
       - superset
       - zookeeper
@@ -532,8 +543,8 @@ stacks:
     stackableRelease: end-to-end-security-release
     stackableOperators:
       - commons
-      - secret
       - listener
+      - secret
       - opa
       - zookeeper
       - hdfs
@@ -602,6 +613,7 @@ stacks:
     stackableRelease: 24.3
     stackableOperators:
       - commons
+      - listener
       - secret
       - zookeeper
       - nifi


### PR DESCRIPTION
We do this to avoid getting `WARN  Unsuccessful data error parse: 404 page not found` during `stackablectl stacklet list`
