### PR TITLE
fix: Bump OPA in stacks, so that v1 rego rules work

### DIFF
--- a/stacks/keycloak-opa-poc/opa.yaml
+++ b/stacks/keycloak-opa-poc/opa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: opa
 spec:
   image:
-    productVersion: 0.57.0
+    productVersion: 0.61.0
   servers:
     roleGroups:
       default: {}

--- a/stacks/trino-iceberg/trino.yaml
+++ b/stacks/trino-iceberg/trino.yaml
@@ -100,7 +100,7 @@ metadata:
   name: opa
 spec:
   image:
-    productVersion: 0.57.0
+    productVersion: 0.61.0
   servers:
     roleGroups:
       default:


### PR DESCRIPTION
Previously we go
`{"level":"error","msg":"Bundle load failed: 1 error occurred: bundles/trino-opa-bundle/trino.rego:3: rego_parse_error: unexpected import path, must begin with one of: {data, future, input}, got: rego\n\timport rego.v1\n\t       ^","name":"stackable","plugin":"bundle","time":"2024-06-24T09:18:50Z"}`