### PR TITLE
Bump end-to-end-security product versions

### DIFF
--- a/demos/end-to-end-security/create-trino-tables.yaml
+++ b/demos/end-to-end-security/create-trino-tables.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: create-tables-in-trino
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable23.11.0
+          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
           command: ["bash", "-c", "python -u /tmp/script/script.py"]
           volumeMounts:
             - name: script

--- a/stacks/end-to-end-security/hive-metastore.yaml
+++ b/stacks/end-to-end-security/hive-metastore.yaml
@@ -9,8 +9,7 @@ spec:
   clusterConfig:
     database:
       connString: jdbc:postgresql://postgresql-hive-iceberg:5432/hive
-      user: hive
-      password: hive
+      credentialsSecret: postgres-credentials
       dbType: postgres
     hdfs:
       configMap: hdfs
@@ -21,3 +20,12 @@ spec:
     roleGroups:
       default:
         replicas: 1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+type: Opaque
+stringData:
+  username: hive
+  password: hive

--- a/stacks/end-to-end-security/opa.yaml
+++ b/stacks/end-to-end-security/opa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: opa
 spec:
   image:
-    productVersion: 0.61.0
+    productVersion: 0.66.0
   clusterConfig:
     userInfo:
       backend:

--- a/stacks/end-to-end-security/superset.yaml
+++ b/stacks/end-to-end-security/superset.yaml
@@ -5,7 +5,7 @@ metadata:
   name: superset
 spec:
   image:
-    productVersion: 3.1.0
+    productVersion: 3.1.3
   clusterConfig:
     listenerClass: external-unstable
     credentialsSecret: superset-credentials

--- a/stacks/end-to-end-security/trino.yaml
+++ b/stacks/end-to-end-security/trino.yaml
@@ -5,7 +5,7 @@ metadata:
   name: trino
 spec:
   image:
-    productVersion: "442"
+    productVersion: "351"
   clusterConfig:
     listenerClass: external-unstable
     tls:

--- a/stacks/end-to-end-security/trino.yaml
+++ b/stacks/end-to-end-security/trino.yaml
@@ -5,7 +5,7 @@ metadata:
   name: trino
 spec:
   image:
-    productVersion: "351"
+    productVersion: "451"
   clusterConfig:
     listenerClass: external-unstable
     tls:

--- a/stacks/end-to-end-security/zookeeper.yaml
+++ b/stacks/end-to-end-security/zookeeper.yaml
@@ -5,7 +5,7 @@ metadata:
   name: zookeeper
 spec:
   image:
-    productVersion: 3.8.3
+    productVersion: 3.9.2
   servers:
     roleGroups:
       default:


### PR DESCRIPTION
product versions bumps 

- hive: adapt to CRD db credential changes
- trino: 442 -> 451
- opa: 0.61 -> 0.66.0
- zookeeper: 3.8.3 -> 3.9.2