### PR TITLE
Fix 24.7 demos

### DIFF
--- a/stacks/data-lakehouse-iceberg-trino-spark/hive-metastores.yaml
+++ b/stacks/data-lakehouse-iceberg-trino-spark/hive-metastores.yaml
@@ -9,9 +9,8 @@ spec:
   clusterConfig:
     database:
       connString: jdbc:postgresql://postgresql-hive:5432/hive
-      user: hive
-      password: hive
       dbType: postgres
+      credentialsSecret: postgres-credentials         
     s3:
       reference: minio
   metastore:
@@ -29,12 +28,20 @@ spec:
   clusterConfig:
     database:
       connString: jdbc:postgresql://postgresql-hive-iceberg:5432/hive
-      user: hive
-      password: hive
       dbType: postgres
+      credentialsSecret: postgres-credentials         
     s3:
       reference: minio
   metastore:
     roleGroups:
       default:
         replicas: 1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+type: Opaque
+stringData:
+  username: hive
+  password: hive

--- a/stacks/data-lakehouse-iceberg-trino-spark/hive-metastores.yaml
+++ b/stacks/data-lakehouse-iceberg-trino-spark/hive-metastores.yaml
@@ -10,7 +10,7 @@ spec:
     database:
       connString: jdbc:postgresql://postgresql-hive:5432/hive
       dbType: postgres
-      credentialsSecret: postgres-credentials         
+      credentialsSecret: postgres-credentials
     s3:
       reference: minio
   metastore:
@@ -29,7 +29,7 @@ spec:
     database:
       connString: jdbc:postgresql://postgresql-hive-iceberg:5432/hive
       dbType: postgres
-      credentialsSecret: postgres-credentials         
+      credentialsSecret: postgres-credentials
     s3:
       reference: minio
   metastore:

--- a/stacks/dual-hive-hdfs-s3/hive.yaml
+++ b/stacks/dual-hive-hdfs-s3/hive.yaml
@@ -41,7 +41,7 @@ spec:
     database:
       connString: jdbc:postgresql://hivehdfs-postgresql:5432/hivehdfs
       dbType: postgres
-      credentialsSecret: postgres-credentials      
+      credentialsSecret: postgres-credentials
     hdfs:
       configMap: hdfs
   metastore:

--- a/stacks/dual-hive-hdfs-s3/hive.yaml
+++ b/stacks/dual-hive-hdfs-s3/hive.yaml
@@ -40,9 +40,8 @@ spec:
   clusterConfig:
     database:
       connString: jdbc:postgresql://hivehdfs-postgresql:5432/hivehdfs
-      user: hive
-      password: hive
       dbType: postgres
+      credentialsSecret: postgres-credentials      
     hdfs:
       configMap: hdfs
   metastore:
@@ -60,12 +59,20 @@ spec:
   clusterConfig:
     database:
       connString: jdbc:postgresql://hives3-postgresql:5432/hives3
-      user: hive
-      password: hive
       dbType: postgres
+      credentialsSecret: postgres-credentials
     s3:
       reference: minio
   metastore:
     roleGroups:
       default:
         replicas: 1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+type: Opaque
+stringData:
+  username: hive
+  password: hive

--- a/stacks/end-to-end-security/krb5.yaml
+++ b/stacks/end-to-end-security/krb5.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       initContainers:
         - name: init
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable24.7.0 # TODO: bump to 1.21.1?
+          image: docker.stackable.tech/stackable/krb5:1.21.1-stackable24.7.0
           args:
             - sh
             - -euo
@@ -35,7 +35,7 @@ spec:
               name: data
       containers:
         - name: kdc
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable24.7.0 # TODO: bump to 1.21.1?
+          image: docker.stackable.tech/stackable/krb5:1.21.1-stackable24.7.0
           args:
             - krb5kdc
             - -n
@@ -48,7 +48,7 @@ spec:
             - mountPath: /var/kerberos/krb5kdc
               name: data
         - name: kadmind
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable24.7.0 # TODO: bump to 1.21.1?
+          image: docker.stackable.tech/stackable/krb5:1.21.1-stackable24.7.0
           args:
             - kadmind
             - -nofork
@@ -61,7 +61,7 @@ spec:
             - mountPath: /var/kerberos/krb5kdc
               name: data
         - name: client
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable24.7.0 # TODO: bump to 1.21.1?
+          image: docker.stackable.tech/stackable/krb5:1.21.1-stackable24.7.0
           tty: true
           stdin: true
           env:

--- a/stacks/nifi-kafka-druid-superset-s3/druid.yaml
+++ b/stacks/nifi-kafka-druid-superset-s3/druid.yaml
@@ -14,6 +14,7 @@ spec:
       connString: jdbc:postgresql://postgresql-druid/druid
       host: postgresql-druid
       port: 5432
+      credentialsSecret: druid-db-credentials
     deepStorage:
       s3:
         bucket:

--- a/stacks/spark-trino-superset-s3/hive-metastore.yaml
+++ b/stacks/spark-trino-superset-s3/hive-metastore.yaml
@@ -10,7 +10,7 @@ spec:
     database:
       connString: jdbc:postgresql://postgresql-hive:5432/hive
       dbType: postgres
-      credentialsSecret: postgres-credentials      
+      credentialsSecret: postgres-credentials
     s3:
       reference: minio
   metastore:
@@ -29,7 +29,7 @@ spec:
     database:
       connString: jdbc:postgresql://postgresql-hive-iceberg:5432/hive
       dbType: postgres
-      credentialsSecret: postgres-credentials      
+      credentialsSecret: postgres-credentials
     s3:
       reference: minio
   metastore:

--- a/stacks/spark-trino-superset-s3/hive-metastore.yaml
+++ b/stacks/spark-trino-superset-s3/hive-metastore.yaml
@@ -28,9 +28,8 @@ spec:
   clusterConfig:
     database:
       connString: jdbc:postgresql://postgresql-hive-iceberg:5432/hive
-      user: hive
-      password: hive
       dbType: postgres
+      credentialsSecret: postgres-credentials      
     s3:
       reference: minio
   metastore:

--- a/stacks/spark-trino-superset-s3/hive-metastore.yaml
+++ b/stacks/spark-trino-superset-s3/hive-metastore.yaml
@@ -9,9 +9,8 @@ spec:
   clusterConfig:
     database:
       connString: jdbc:postgresql://postgresql-hive:5432/hive
-      user: hive
-      password: hive
       dbType: postgres
+      credentialsSecret: postgres-credentials      
     s3:
       reference: minio
   metastore:
@@ -38,3 +37,12 @@ spec:
     roleGroups:
       default:
         replicas: 1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+type: Opaque
+stringData:
+  username: hive
+  password: hive

--- a/stacks/trino-iceberg/hive-metastores.yaml
+++ b/stacks/trino-iceberg/hive-metastores.yaml
@@ -10,7 +10,7 @@ spec:
     database:
       connString: jdbc:postgresql://postgresql-hive-iceberg:5432/hive
       dbType: postgres
-      credentialsSecret: postgres-credentials      
+      credentialsSecret: postgres-credentials
     s3:
       reference: minio
   metastore:

--- a/stacks/trino-iceberg/hive-metastores.yaml
+++ b/stacks/trino-iceberg/hive-metastores.yaml
@@ -9,12 +9,20 @@ spec:
   clusterConfig:
     database:
       connString: jdbc:postgresql://postgresql-hive-iceberg:5432/hive
-      user: hive
-      password: hive
       dbType: postgres
+      credentialsSecret: postgres-credentials      
     s3:
       reference: minio
   metastore:
     roleGroups:
       default:
         replicas: 1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+type: Opaque
+stringData:
+  username: hive
+  password: hive

--- a/stacks/trino-superset-s3/hive-metastore.yaml
+++ b/stacks/trino-superset-s3/hive-metastore.yaml
@@ -10,7 +10,7 @@ spec:
     database:
       connString: jdbc:postgresql://postgresql-hive:5432/hive
       dbType: postgres
-      credentialsSecret: postgres-credentials      
+      credentialsSecret: postgres-credentials
     s3:
       reference: minio
   metastore:

--- a/stacks/trino-superset-s3/hive-metastore.yaml
+++ b/stacks/trino-superset-s3/hive-metastore.yaml
@@ -9,12 +9,20 @@ spec:
   clusterConfig:
     database:
       connString: jdbc:postgresql://postgresql-hive:5432/hive
-      user: hive
-      password: hive
       dbType: postgres
+      credentialsSecret: postgres-credentials      
     s3:
       reference: minio
   metastore:
     roleGroups:
       default:
         replicas: 1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+type: Opaque
+stringData:
+  username: hive
+  password: hive        


### PR DESCRIPTION
- stack/end-to-end-security: change krb5 version to 1.21.1
- stack/nifi-kafka-druid-superset-s3: use `credentialsSecret: druid-db-credentials` in druid cluster yaml
- adapt to hive breaking credential secret changes