### PR TITLE
fix(trino-iceberg): remove invalid OpaCluster configuration

### DIFF
--- a/stacks/trino-iceberg/trino.yaml
+++ b/stacks/trino-iceberg/trino.yaml
@@ -103,10 +103,7 @@ spec:
     productVersion: 0.57.0
   servers:
     roleGroups:
-      default:
-        selector:
-          matchLabels:
-            kubernetes.io/os: linux
+      default: {}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
This was leftover from stackabletech/operator-rs#652, and somehow got missed in the previous release demo testing.

This doesn't fix it completely, as the stacks/demos still point to the `main` branch, but that will be fixed separately in https://github.com/stackabletech/demos/issues/66