### PR TITLE
fix: remove page aliases to avoid duplication

### DIFF
--- a/docs/modules/demos/pages/airflow-scheduled-job.adoc
+++ b/docs/modules/demos/pages/airflow-scheduled-job.adoc
@@ -1,5 +1,4 @@
 = airflow-scheduled-job
-:page-aliases: stable@stackablectl::demos/airflow-scheduled-job.adoc
 
 Install this demo on an existing Kubernetes cluster:
 

--- a/docs/modules/demos/pages/data-lakehouse-iceberg-trino-spark.adoc
+++ b/docs/modules/demos/pages/data-lakehouse-iceberg-trino-spark.adoc
@@ -1,5 +1,4 @@
 = data-lakehouse-iceberg-trino-spark
-:page-aliases: stable@stackablectl::demos/data-lakehouse-iceberg-trino-spark.adoc
 
 :demo-code: https://github.com/stackabletech/demos/blob/main/demos/data-lakehouse-iceberg-trino-spark/create-spark-ingestion-job.yaml
 :iceberg-table-maintenance: https://iceberg.apache.org/docs/latest/spark-procedures/#metadata-management

--- a/docs/modules/demos/pages/hbase-hdfs-load-cycling-data.adoc
+++ b/docs/modules/demos/pages/hbase-hdfs-load-cycling-data.adoc
@@ -1,5 +1,4 @@
 = hbase-hdfs-cycling-data
-:page-aliases: stable@stackablectl::demos/hbase-hdfs-load-cycling-data.adoc
 
 :kaggle: https://www.kaggle.com/datasets/timgid/cyclistic-dataset-google-certificate-capstone?select=Divvy_Trips_2020_Q1.csv
 :k8s-cpu: https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#cpu

--- a/docs/modules/demos/pages/index.adoc
+++ b/docs/modules/demos/pages/index.adoc
@@ -1,5 +1,4 @@
 = Demos
-:page-aliases: stable@stackablectl::demos/index.adoc
 
 The pages below this section guide you on how to use the demos provided by Stackable. To install a demo please follow
 the xref:management:stackablectl:quickstart.adoc[quickstart guide] or have a look at the

--- a/docs/modules/demos/pages/jupyterhub-pyspark-hdfs-anomaly-detection-taxi-data.adoc
+++ b/docs/modules/demos/pages/jupyterhub-pyspark-hdfs-anomaly-detection-taxi-data.adoc
@@ -1,5 +1,4 @@
 = jupyterhub-pyspark-hdfs-anomaly-detection-taxi-data
-:page-aliases: stable@stackablectl::demos/jupyterhub-pyspark-hdfs-anomaly-detection-taxi-data.adoc
 
 :scikit-lib: https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.IsolationForest.html
 :k8s-cpu: https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#cpu

--- a/docs/modules/demos/pages/logging.adoc
+++ b/docs/modules/demos/pages/logging.adoc
@@ -1,5 +1,4 @@
 = logging
-:page-aliases: stable@stackablectl::demos/logging.adoc
 
 :k8s-cpu: https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#cpu
 

--- a/docs/modules/demos/pages/nifi-kafka-druid-earthquake-data.adoc
+++ b/docs/modules/demos/pages/nifi-kafka-druid-earthquake-data.adoc
@@ -1,5 +1,4 @@
 = nifi-kafka-druid-earthquake-data
-:page-aliases: stable@stackablectl::demos/nifi-kafka-druid-earthquake-data.adoc
 
 :superset-docs: https://superset.apache.org/docs/using-superset/creating-your-first-dashboard/#creating-charts-in-explore-view
 :druid-tutorial: https://druid.apache.org/docs/latest/tutorials/tutorial-kafka.html#loading-data-with-the-data-loader

--- a/docs/modules/demos/pages/nifi-kafka-druid-water-level-data.adoc
+++ b/docs/modules/demos/pages/nifi-kafka-druid-water-level-data.adoc
@@ -1,5 +1,4 @@
 = nifi-kafka-druid-water-level-data
-:page-aliases: stable@stackablectl::demos/nifi-kafka-druid-water-level-data.adoc
 
 :superset: https://superset.apache.org/docs/using-superset/creating-your-first-dashboard/#creating-charts-in-explore-view
 :druid-tutorial: https://druid.apache.org/docs/latest/tutorials/tutorial-kafka.html#loading-data-with-the-data-loader

--- a/docs/modules/demos/pages/spark-k8s-anomaly-detection-taxi-data.adoc
+++ b/docs/modules/demos/pages/spark-k8s-anomaly-detection-taxi-data.adoc
@@ -1,5 +1,4 @@
 = spark-k8s-anomaly-detection-taxi-data
-:page-aliases: stable@stackablectl::demos/spark-k8s-anomaly-detection-taxi-data.adoc
 
 :scikit-lib: https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.IsolationForest.html
 :k8s-cpu: https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#cpu

--- a/docs/modules/demos/pages/trino-iceberg.adoc
+++ b/docs/modules/demos/pages/trino-iceberg.adoc
@@ -1,5 +1,4 @@
 = trino-iceberg
-:page-aliases: stable@stackablectl::demos/trino-iceberg.adoc
 
 :k8s-cpu: https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#cpu
 :tcph-spec: https://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.1.pdf

--- a/docs/modules/demos/pages/trino-taxi-data.adoc
+++ b/docs/modules/demos/pages/trino-taxi-data.adoc
@@ -1,5 +1,4 @@
 = trino-taxi-data
-:page-aliases: stable@stackablectl::demos/trino-taxi-data.adoc
 
 :superset-docs: https://superset.apache.org/docs/creating-charts-dashboards/creating-your-first-dashboard#creating-charts-in-explore-view
 :nyc-website: https://www1.nyc.gov/assets/tlc/downloads/pdf/data_dictionary_trip_records_yellow.pdf


### PR DESCRIPTION
It seems that the page-aliases (for when demos used to be in the stackablectl repo) are only valid in nightly (because stackable-cockpit docs are only built on `main`.

Co-authored-by: xeniape <xenia.fischer@stackable.tech>