### PR TITLE
chore: Bump Vector to 0.40.0

### DIFF
--- a/stacks/_templates/vector-aggregator.yaml
+++ b/stacks/_templates/vector-aggregator.yaml
@@ -3,7 +3,7 @@ name: vector
 repo:
   name: vector
   url: https://helm.vector.dev
-version: 0.34.0
+version: 0.35.0 # app version 0.40.0
 options:
   commonLabels:
     stackable.tech/vendor: Stackable


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/626

```[tasklist]
### Depends on
- [ ] https://github.com/stackabletech/docker-images/pull/802
```

> [!CAUTION]
> This PR is raised against the `next` branch so that demos aren't broken (resolved in future by https://github.com/stackabletech/stackable-cockpit/issues/310)