### PR TITLE
chore(airflow): bump version to 2.9.3

### DIFF
--- a/stacks/airflow/airflow.yaml
+++ b/stacks/airflow/airflow.yaml
@@ -6,7 +6,7 @@ metadata:
   name: airflow
 spec:
   image:
-    productVersion: 2.9.2
+    productVersion: 2.9.3
   clusterConfig:
     listenerClass: external-unstable
     loadExamples: false


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/626

```[tasklist]
### Dependencies
- [ ] https://github.com/stackabletech/docker-images/pull/809
```

> [!CAUTION]
> This PR is raised against the `next` branch so that demos aren't broken (resolved in future by https://github.com/stackabletech/stackable-cockpit/issues/310)