### PR TITLE
chore: Upgrade the Vector aggregator

### DIFF
--- a/stacks/_templates/vector-aggregator.yaml
+++ b/stacks/_templates/vector-aggregator.yaml
@@ -3,11 +3,11 @@ name: vector
 repo:
   name: vector
   url: https://helm.vector.dev
-version: 0.35.0 # app version 0.40.0
+version: 0.36.1 # app version 0.41.1
 options:
   commonLabels:
     stackable.tech/vendor: Stackable
-  podLabels: # Doesn't seem to work?
+  podLabels:
     stackable.tech/vendor: Stackable
   role: Aggregator
   customConfig:
@@ -25,7 +25,7 @@ options:
           - https://opensearch-cluster-master.default.svc.cluster.local:9200
         mode: bulk
         # The auto-detection of the API version does not work in Vector
-        # 0.39.0 for OpenSearch, so the version must be set explicitly
+        # 0.41.1 for OpenSearch, so the version must be set explicitly
         # (see https://github.com/vectordotdev/vector/issues/17690).
         api_version: v8
         tls:


### PR DESCRIPTION
Upgrade the Vector aggregator to version 0.41.1

part of stackabletech/docker-images#845

Comment removed because the label is set on the pod:

```diff
-  podLabels: # Doesn't seem to work?
+  podLabels:
     stackable.tech/vendor: Stackable
```

```shell
$ kubectl get pods vector-aggregator-0 -o yaml
apiVersion: v1
kind: Pod
metadata:
  namespace: default
  name: vector-aggregator-0
  labels:
    app.kubernetes.io/component: Aggregator
    app.kubernetes.io/instance: vector-aggregator
    app.kubernetes.io/name: vector
    apps.kubernetes.io/pod-index: "0"
    controller-revision-hash: vector-aggregator-5498ff4f5d
    stackable.tech/vendor: Stackable
    statefulset.kubernetes.io/pod-name: vector-aggregator-0
    vector.dev/exclude: "true"
```