### PR TITLE
ci: Replace pyspark with spark base-image

### DIFF
--- a/demos/jupyterhub-pyspark-hdfs-anomaly-detection-taxi-data/Dockerfile
+++ b/demos/jupyterhub-pyspark-hdfs-anomaly-detection-taxi-data/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.stackable.tech/stackable/pyspark-k8s:3.4.0-stackable23.7.0
+FROM docker.stackable.tech/stackable/spark-k8s:3.5.1-stackable24.7.0
 
 COPY demos/jupyterhub-pyspark-hdfs-anomaly-detection-taxi-data/requirements.txt .
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/infrastructure/issues/143, fix broken build pipeline und update base-image (outdated pyspark image, also not available for arm)