### PR TITLE
ci: Only publish manifest for amd for spark-k8s-with-scikit-learn image

### DIFF
--- a/.github/workflows/dev_spark-k8s-with-scikit-learn.yaml
+++ b/.github/workflows/dev_spark-k8s-with-scikit-learn.yaml
@@ -29,6 +29,7 @@ jobs:
           - {name: "ubuntu-latest", arch: "amd64"}
           # TODO: the image 3.5.0-stackable24.3.0 does not have an arm64 build.
           # Re-activate the arm runner when the image is updated to one that does.
+          # Also adjust publish_manifest step to include arm architecture
           #- {name: "ubicloud-standard-8-arm", arch: "arm64"}
     steps:
       - name: Checkout Repository
@@ -72,6 +73,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      # TODO: remove image-architecture key once arm image is also built
       - name: Publish and Sign Image Index Manifest to docker.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # v0.0.6
         with:
@@ -80,7 +82,9 @@ jobs:
           image-registry-password: ${{ secrets.NEXUS_PASSWORD }}
           image-repository: demos/${{ env.IMAGE_NAME }}
           image-index-manifest-tag: ${{ env.IMAGE_VERSION }}
+          image-architectures: '["amd64"]'
 
+      # TODO: remove image-architecture key once arm image is also built
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: stackabletech/actions/publish-index-manifest@013e6482fbc0edf2d38cf9220fc931f6a81336fb # v0.0.6
         with:
@@ -89,3 +93,4 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: ${{ env.REGISTRY_PATH }}/${{ env.IMAGE_NAME }}
           image-index-manifest-tag: ${{ env.IMAGE_VERSION }}
+          image-architectures: '["amd64"]'


### PR DESCRIPTION
Follow up of https://github.com/stackabletech/demos/pull/112 (only amd is built currently as mentioned in the PR code)