### PR TITLE
fix: Use dev release for stacks

### DIFF
--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -2,7 +2,7 @@
 stacks:
   monitoring:
     description: Stack containing Prometheus and Grafana
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -25,7 +25,7 @@ stacks:
         default: adminadmin
   logging:
     description: Stack containing OpenSearch, OpenSearch Dashboards (Kibana) and Vector aggregator
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -85,7 +85,7 @@ stacks:
         default: adminadmin
   airflow:
     description: Stack containing Airflow scheduling platform
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -112,7 +112,7 @@ stacks:
         default: airflowSecretKey
   data-lakehouse-iceberg-trino-spark:
     description: Data lakehouse using Iceberg lakehouse on S3, Trino as query engine, Spark for streaming ingest and Superset for data visualization
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -169,7 +169,7 @@ stacks:
         default: supersetSecretKey
   hdfs-hbase:
     description: HBase cluster using HDFS as underlying storage
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -192,7 +192,7 @@ stacks:
     parameters: []
   nifi-kafka-druid-superset-s3:
     description: Stack containing NiFi, Kafka, Druid, MinIO and Superset for data visualization
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -238,7 +238,7 @@ stacks:
         default: adminadmin
   spark-trino-superset-s3:
     description: Stack containing MinIO, Trino and Superset for data visualization
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -283,7 +283,7 @@ stacks:
         default: supersetSecretKey
   trino-superset-s3:
     description: Stack containing MinIO, Trino and Superset for data visualization
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -325,7 +325,7 @@ stacks:
         default: supersetSecretKey
   trino-iceberg:
     description: Stack containing Trino using Apache Iceberg as a S3 data lakehouse
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -359,7 +359,7 @@ stacks:
         default: adminadmin
   jupyterhub-pyspark-hdfs:
     description: Jupyterhub with PySpark and HDFS integration
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -389,7 +389,7 @@ stacks:
         default: adminadmin
   dual-hive-hdfs-s3:
     description: Dual stack Hive on HDFS and S3 for Hadoop/Hive to Trino migration
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -426,7 +426,7 @@ stacks:
       The bind user credentials are: ldapadmin:ldapadminpassword.
       No AuthenticationClass is configured, The AuthenticationClass is created manually in the tutorial.
       Use the 'openldap' Stack for an OpenLDAD with an AuthenticationClass already installed.
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -449,7 +449,7 @@ stacks:
       The bind user credentials are: ldapadmin:ldapadminpassword.
       The LDAP AuthenticationClass is called 'ldap' and the SecretClass for the bind credentials is called 'ldap-bind-credentials'.
       The stack already creates an appropriate Secret, so referring to the 'ldap' AuthenticationClass in your ProductCluster should be enough.
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -475,7 +475,7 @@ stacks:
       3 users are created in Keycloak: admin:adminadmin, alice:alicealice, bob:bobbob. admin and alice are admins with
       full authorization in Druid and Trino, bob is not authorized.
       This is a proof-of-concept and the mechanisms used here are subject to change.
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -541,7 +541,7 @@ stacks:
 
       Note that this stack is tightly coupled with the demo.
       So if you install the stack you will get demo-specific parts (such as Keycloak users or regorules).
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener
@@ -611,7 +611,7 @@ stacks:
   signal-processing:
     description: >-
       A stack used for creating, streaming and processing in-flight data and persisting it to TimescaleDB before it is displayed in Grafana
-    stackableRelease: 24.7
+    stackableRelease: dev
     stackableOperators:
       - commons
       - listener


### PR DESCRIPTION
As we already bumped the stack and demo manifests before the 24.11 release in https://github.com/stackabletech/demos/pull/116, we should at least use the dev versions, so that the demos are not completely broken.

This avoids the need for the users to run `stackablectl release in dev && stackablectl demo in trino-taxi-data --skip-release`