### PR TITLE
fix: Use different delimter in sed expressions

### DIFF
--- a/.scripts/update_refs.sh
+++ b/.scripts/update_refs.sh
@@ -49,7 +49,7 @@ if [[ "$CURRENT_BRANCH" == release-* ]]; then
   # NOTE (@NickLarsenNZ): find is not required for such a trivial case, but it is done for consitency
   find stacks/stacks-v2.yaml \
     -exec grep --color=always -l stackableRelease {} \; \
-    -exec sed -i -E "s|(stackableRelease:\s+)(\S+)|\1${STACKABLE_RELEASE}|" {} \; \
+    -exec sed -i -E "s#(stackableRelease:\s+)(\S+)#\1${STACKABLE_RELEASE}#" {} \; \
   | prepend "\t"
   maybe_commit "chore(release): $MESSAGE"
 
@@ -61,7 +61,7 @@ if [[ "$CURRENT_BRANCH" == release-* ]]; then
   echo "$MESSAGE"
   find demos stacks -type f \
     -exec grep --color=always -lE "$SEARCH" {} \; \
-    -exec sed -i -E "s|${SEARCH}|${REPLACEMENT}|" {} \; \
+    -exec sed -i -E "s#${SEARCH}#${REPLACEMENT}#" {} \; \
   | prepend "\t"
   maybe_commit "chore(release): $MESSAGE"
 
@@ -80,7 +80,7 @@ echo "$MESSAGE"
 # shellcheck disable=SC2016 # We intentionally don't want to expand the variable.
 find demos stacks -type f \
   -exec grep --color=always -l githubusercontent {} \; \
-  -exec sed -i -E 's|(stackabletech/demos)/main/|\1/\${UPDATE_BRANCH_REF}/|' {} \; \
+  -exec sed -i -E 's#(stackabletech/demos)/main/#\1/\${UPDATE_BRANCH_REF}/#' {} \; \
 | prepend "\t"
 
 # Now, for all modified files, we can use envsubst


### PR DESCRIPTION
`|` was a bad delimiter because one expression contains an or. Instead of escaping `|` for the or, it is better to use a less common character as the delimiter.

Fixes #132