### PR TITLE
fix(stack/end-to-end-security): Skip DB restore if the DB exists

### DIFF
--- a/stacks/end-to-end-security/superset.yaml
+++ b/stacks/end-to-end-security/superset.yaml
@@ -46,6 +46,11 @@ spec:
               - bash
               - -c
               - |
+                if psql --host postgresql-superset --user postgres --csv -c "SELECT datname FROM pg_database where datname = 'superset' limit 1" | grep -q superset; then
+                  # The flask app will do any necesary migrations.
+                  echo "Skip restoring the DB as it already exists"
+                  exit 0
+                fi
                 psql --host postgresql-superset --user postgres < /dump/postgres_superset_dump.sql
             env:
               - name: PGPASSWORD


### PR DESCRIPTION
Otherwise it breaks with:

```
ERROR [flask_migrate] Error: Requested revision 17fcea065655 overlaps with other requested revisions b7851ee5522f
```

The latter revision being the one that exists in the uploaded dump.

### test

<details><summary>:poop: fails</summary>

1. ![image](https://github.com/user-attachments/assets/84e5fca7-ebed-45cf-9a9f-125823709054)
2. ![image](https://github.com/user-attachments/assets/740d30f0-9b6a-4f2f-82a7-a994b705a701)

</details>

![image](https://github.com/user-attachments/assets/57e3fad8-6c9f-4a71-bc6a-5029e9db58a5)

