### PR TITLE
fix(stack/end-to-end-security): Skip DB restore if the DB exists

### DIFF
--- a/stacks/end-to-end-security/superset.yaml
+++ b/stacks/end-to-end-security/superset.yaml
@@ -47,7 +47,7 @@ spec:
               - -c
               - |
                 if psql --host postgresql-superset --user postgres --csv -c "SELECT datname FROM pg_database where datname = 'superset' limit 1" | grep -q superset; then
-                  # The flask app will do any necesary migrations.
+                  # The flask app will do any necessary migrations.
                   echo "Skip restoring the DB as it already exists"
                   exit 0
                 fi

--- a/stacks/end-to-end-security/superset.yaml
+++ b/stacks/end-to-end-security/superset.yaml
@@ -46,6 +46,11 @@ spec:
               - bash
               - -c
               - |
+                if psql --host postgresql-superset --user postgres --csv -c "SELECT datname FROM pg_database where datname = 'superset' limit 1" | grep -q superset; then
+                  # The flask app will do any necesary migrations.
+                  echo "Skip restoring the DB as it already exists"
+                  exit 0
+                fi
                 psql --host postgresql-superset --user postgres < /dump/postgres_superset_dump.sql
             env:
               - name: PGPASSWORD


### PR DESCRIPTION
Companion change: https://github.com/stackabletech/demos/pull/139

Skip DB restore if the DB exists otherwise it breaks with:

```
ERROR [flask_migrate] Error: Requested revision 17fcea065655 overlaps with other requested revisions b7851ee5522f
```

The latter revision being the one that exists in the uploaded dump.