### PR TITLE
Updating helm chart to app version 0.43.1

### DIFF
--- a/stacks/_templates/vector-aggregator.yaml
+++ b/stacks/_templates/vector-aggregator.yaml
@@ -4,7 +4,7 @@ name: vector
 repo:
   name: vector
   url: https://helm.vector.dev
-version: 0.36.1 # app version 0.41.1
+version: 0.39.0 # app version 0.43.1
 options:
   commonLabels:
     stackable.tech/vendor: Stackable


### PR DESCRIPTION
Updating `vector-aggregator` helm chart to `0.39.0` with app version `0.43.1` following https://github.com/stackabletech/docker-images/issues/967