### PR TITLE
chore(kafka): Bump to 3.9.0

### DIFF
--- a/stacks/data-lakehouse-iceberg-trino-spark/kafka.yaml
+++ b/stacks/data-lakehouse-iceberg-trino-spark/kafka.yaml
@@ -13,7 +13,7 @@ metadata:
   name: kafka
 spec:
   image:
-    productVersion: 3.8.0
+    productVersion: 3.9.0
   clusterConfig:
     zookeeperConfigMapName: kafka-znode
     authentication:

--- a/stacks/nifi-kafka-druid-superset-s3/kafka.yaml
+++ b/stacks/nifi-kafka-druid-superset-s3/kafka.yaml
@@ -13,7 +13,7 @@ metadata:
   name: kafka
 spec:
   image:
-    productVersion: 3.8.0
+    productVersion: 3.9.0
   clusterConfig:
     zookeeperConfigMapName: kafka-znode
     authentication:


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/968.

Bump demos to use Kafka 3.9.0.