### PR TITLE
fix: E2E Security demo - Separate DB setup from superset resource

### DIFF
--- a/stacks/end-to-end-security/rbac.yaml
+++ b/stacks/end-to-end-security/rbac.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: superset-job-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: superset-job-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: superset-job-role
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch

--- a/stacks/end-to-end-security/setup-postgresql.yaml
+++ b/stacks/end-to-end-security/setup-postgresql.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: setup-db-job
+spec:
+  template:
+    spec:
+      initContainers:
+        # The postgres image does not contain curl or wget...
+        - name: download-dump
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          command:
+            - bash
+            - -c
+            - |
+              kubectl rollout status --watch statefulset/postgresql-superset
+              cd /tmp
+              curl --fail -O https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/postgres_superset_dump.sql.gz
+              gunzip postgres_superset_dump.sql.gz
+
+              # We need to omit changing the users password, as otherwise the content in the Secrets does not match
+              # the actual password in Postgres.
+              grep -vwE '(CREATE ROLE postgres;|CREATE ROLE superset;|ALTER ROLE postgres|ALTER ROLE superset)' postgres_superset_dump.sql > /dump/postgres_superset_dump.sql
+          volumeMounts:
+            - name: dump
+              mountPath: /dump/
+      containers:
+        - name: restore-postgres
+          image: docker.io/bitnami/postgresql:16.1.0-debian-11-r11 # Same image as the bitnami postgres helm-chart is using
+          command:
+            - bash
+            - -c
+            - |
+              echo "Preparing restore..."
+              psql --host postgresql-superset --user postgres < /dump/postgres_superset_dump.sql
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-superset
+                  key: postgres-password
+          volumeMounts:
+            - name: dump
+              mountPath: /dump/
+      volumes:
+        - name: dump
+          emptyDir: {}
+      restartPolicy: OnFailure
+  backoffLimit: 20

--- a/stacks/end-to-end-security/superset.yaml
+++ b/stacks/end-to-end-security/superset.yaml
@@ -21,49 +21,14 @@ spec:
         replicas: 1
     podOverrides:
       spec:
-        # We need to restore the postgres state before the superset container itself starts some database migrations
         initContainers:
-          # The postgres image does not contain curl or wget...
-          - name: download-dump
+          - name: wait-for-setup-db-job
             image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
             command:
               - bash
               - -c
               - |
-                cd /tmp
-                curl --fail -O https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/postgres_superset_dump.sql.gz
-                gunzip postgres_superset_dump.sql.gz
-
-                # We need to omit changing the users password, as otherwise the content in the Secrets does not match
-                # the actual password in Postgres.
-                grep -vwE '(CREATE ROLE postgres;|CREATE ROLE superset;|ALTER ROLE postgres|ALTER ROLE superset)' postgres_superset_dump.sql > /dump/postgres_superset_dump.sql
-            volumeMounts:
-              - name: dump
-                mountPath: /dump/
-          - name: restore-postgres
-            image: docker.io/bitnami/postgresql:16.1.0-debian-11-r11 # Same image as the bitnami postgres helm-chart is using
-            command:
-              - bash
-              - -c
-              - |
-                if psql --host postgresql-superset --user postgres --csv -c "SELECT datname FROM pg_database where datname = 'superset' limit 1" | grep -q superset; then
-                  # The flask app will do any necessary migrations.
-                  echo "Skip restoring the DB as it already exists"
-                  exit 0
-                fi
-                psql --host postgresql-superset --user postgres < /dump/postgres_superset_dump.sql
-            env:
-              - name: PGPASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: postgresql-superset
-                    key: postgres-password
-            volumeMounts:
-              - name: dump
-                mountPath: /dump/
-        volumes:
-          - name: dump
-            emptyDir: {}
+                kubectl wait --for=condition=complete job/setup-db-job
 ---
 apiVersion: v1
 kind: Secret

--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -582,7 +582,9 @@ stacks:
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/trino.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/trino-regorules.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/trino-policies.yaml
-      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/superset.yaml
+      - plainYaml: stacks/end-to-end-security/rbac.yaml
+      - plainYaml: stacks/end-to-end-security/setup-postgresql.yaml
+      - plainYaml: stacks/end-to-end-security/superset.yaml
     parameters:
       - name: keycloakAdminPassword
         description: Password of the Keycloak admin user

--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -582,9 +582,9 @@ stacks:
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/trino.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/trino-regorules.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/trino-policies.yaml
-      - plainYaml: stacks/end-to-end-security/rbac.yaml
-      - plainYaml: stacks/end-to-end-security/setup-postgresql.yaml
-      - plainYaml: stacks/end-to-end-security/superset.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/rbac.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/setup-postgresql.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/end-to-end-security/superset.yaml
     parameters:
       - name: keycloakAdminPassword
         description: Password of the Keycloak admin user


### PR DESCRIPTION
The postgresl dump file contains the dashboard assets, created under an earlier version of superset (3.x). Since the upgrade to 4.x there appears to be changes made (by flask?) to the database that overwrite the restore action. This PR move the DB initialization to a separate step. It now looks like this:

- postgres installed via helm
- once the postgres statefulset is ready, a job runs that downloads the dump file and restores it
- superset waits for this job to complete but does not restore anything (although there will a DB migration due to the version differences)

Logged in via Keycloak:

![image](https://github.com/user-attachments/assets/c0ad18bb-a9da-4dd5-af80-48fac5cffcf5)
