### PR TITLE
chore(nifi): Bump to 1.28.1, upgrade postgres jdbc driver

### DIFF
--- a/.github/workflows/dev_nifi.yaml
+++ b/.github/workflows/dev_nifi.yaml
@@ -5,7 +5,7 @@ env:
   IMAGE_NAME: nifi
   # TODO (@NickLarsenNZ): Use a versioned image with stackable0.0.0-dev or stackableXX.X.X so that
   # the demo is reproducable for the release and it will be automatically replaced for the release branch.
-  IMAGE_VERSION: 2.2.0-postgresql
+  IMAGE_VERSION: 1.28.1-postgresql
   REGISTRY_PATH: stackable
   DOCKERFILE_PATH: "demos/signal-processing/Dockerfile-nifi"
 

--- a/.github/workflows/dev_nifi.yaml
+++ b/.github/workflows/dev_nifi.yaml
@@ -5,7 +5,7 @@ env:
   IMAGE_NAME: nifi
   # TODO (@NickLarsenNZ): Use a versioned image with stackable0.0.0-dev or stackableXX.X.X so that
   # the demo is reproducable for the release and it will be automatically replaced for the release branch.
-  IMAGE_VERSION: 1.27.0-postgresql
+  IMAGE_VERSION: 2.2.0-postgresql
   REGISTRY_PATH: stackable
   DOCKERFILE_PATH: "demos/signal-processing/Dockerfile-nifi"
 

--- a/demos/demos-v2.yaml
+++ b/demos/demos-v2.yaml
@@ -85,6 +85,7 @@ demos:
       - s3
       - water-levels
     manifests:
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-water-level-data/serviceaccount.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-water-level-data/create-nifi-ingestion-job.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-water-level-data/create-druid-ingestion-job.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-water-level-data/setup-superset.yaml

--- a/demos/demos-v2.yaml
+++ b/demos/demos-v2.yaml
@@ -64,6 +64,7 @@ demos:
       - s3
       - earthquakes
     manifests:
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-earthquake-data/serviceaccount.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-earthquake-data/create-nifi-ingestion-job.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-earthquake-data/create-druid-ingestion-job.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-earthquake-data/setup-superset.yaml

--- a/demos/nifi-kafka-druid-earthquake-data/create-druid-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-earthquake-data/create-druid-ingestion-job.yaml
@@ -6,10 +6,30 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: demo-serviceaccount
+      initContainers:
+        - name: wait-for-druid-coordinator
+          image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              echo 'Waiting for Druid Coordinator to be created'
+              kubectl wait --for=create pod/druid-coordinator-default-0
+              echo 'Waiting for Druid Coordinator to be ready'
+              kubectl wait --for=condition=Ready pod/druid-coordinator-default-0 --timeout=30m
       containers:
         - name: create-druid-ingestion-job
           image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
-          command: ["bash", "-c", "curl -X POST --insecure -H 'Content-Type: application/json' -d @/tmp/ingestion-job-spec/ingestion-job-spec.json https://druid-coordinator:8281/druid/indexer/v1/supervisor"]
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              curl -X POST --insecure -H 'Content-Type: application/json' -d @/tmp/ingestion-job-spec/ingestion-job-spec.json https://druid-coordinator:8281/druid/indexer/v1/supervisor
           volumeMounts:
             - name: ingestion-job-spec
               mountPath: /tmp/ingestion-job-spec

--- a/demos/nifi-kafka-druid-earthquake-data/create-nifi-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-earthquake-data/create-nifi-ingestion-job.yaml
@@ -6,10 +6,31 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: demo-serviceaccount
+      initContainers:
+        - name: wait-for-nifi
+          image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              echo 'Waiting for NiFi to be created'
+              kubectl wait --for=create pod/nifi-node-default-0 --timeout=30m
+              echo 'Waiting for NiFi to be ready'
+              kubectl wait --for=condition=Ready pod/nifi-node-default-0 --timeout=30m
       containers:
         - name: create-nifi-ingestion-job
           image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
-          command: ["bash", "-c", "curl -O https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-earthquake-data/IngestEarthquakesToKafka.xml && python -u /tmp/script/script.py"]
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              curl -O https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-earthquake-data/IngestEarthquakesToKafka.xml
+              python -u /tmp/script/script.py
           volumeMounts:
             - name: script
               mountPath: /tmp/script

--- a/demos/nifi-kafka-druid-earthquake-data/serviceaccount.yaml
+++ b/demos/nifi-kafka-druid-earthquake-data/serviceaccount.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: demo-serviceaccount
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: demo-clusterrolebinding
+subjects:
+  - kind: ServiceAccount
+    name: demo-serviceaccount
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: demo-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: demo-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create

--- a/demos/nifi-kafka-druid-earthquake-data/setup-superset.yaml
+++ b/demos/nifi-kafka-druid-earthquake-data/setup-superset.yaml
@@ -6,10 +6,31 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: demo-serviceaccount
+      initContainers:
+        - name: wait-for-superset
+          image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              echo 'Waiting for Superset to be created'
+              kubectl wait --for=create pod/superset-node-default-0 --timeout=30m
+              echo 'Waiting for Superset to be ready'
+              kubectl wait --for=condition=Ready pod/superset-node-default-0 --timeout=30m
       containers:
         - name: setup-superset
           image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
-          command: ["bash", "-c", "curl -o superset-assets.zip https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-earthquake-data/superset-assets.zip && python -u /tmp/script/script.py"]
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              curl -o superset-assets.zip https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-earthquake-data/superset-assets.zip
+              python -u /tmp/script/script.py
           volumeMounts:
             - name: script
               mountPath: /tmp/script

--- a/demos/nifi-kafka-druid-water-level-data/create-druid-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-water-level-data/create-druid-ingestion-job.yaml
@@ -6,10 +6,32 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: demo-serviceaccount
+      initContainers:
+        - name: wait-for-druid-coordinator
+          image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              echo 'Waiting for Druid Coordinator to be created'
+              kubectl wait --for=create pod/druid-coordinator-default-0
+              echo 'Waiting for Druid Coordinator to be ready'
+              kubectl wait --for=condition=Ready pod/druid-coordinator-default-0 --timeout=30m
       containers:
         - name: create-druid-ingestion-job
           image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
-          command: ["bash", "-c", "curl -X POST --insecure -H 'Content-Type: application/json' -d @/tmp/ingestion-job-spec/stations-ingestion-job-spec.json https://druid-coordinator:8281/druid/indexer/v1/supervisor && curl -X POST --insecure -H 'Content-Type: application/json' -d @/tmp/ingestion-job-spec/measurements-ingestion-job-spec.json https://druid-coordinator:8281/druid/indexer/v1/supervisor && curl -X POST --insecure -H 'Content-Type: application/json' -d @/tmp/ingestion-job-spec/measurements-compaction-job-spec.json https://druid-coordinator:8281/druid/coordinator/v1/config/compaction"]
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              curl -X POST --insecure -H 'Content-Type: application/json' -d @/tmp/ingestion-job-spec/stations-ingestion-job-spec.json https://druid-coordinator:8281/druid/indexer/v1/supervisor
+              curl -X POST --insecure -H 'Content-Type: application/json' -d @/tmp/ingestion-job-spec/measurements-ingestion-job-spec.json https://druid-coordinator:8281/druid/indexer/v1/supervisor
+              curl -X POST --insecure -H 'Content-Type: application/json' -d @/tmp/ingestion-job-spec/measurements-compaction-job-spec.json https://druid-coordinator:8281/druid/coordinator/v1/config/compaction
           volumeMounts:
             - name: ingestion-job-spec
               mountPath: /tmp/ingestion-job-spec

--- a/demos/nifi-kafka-druid-water-level-data/create-nifi-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-water-level-data/create-nifi-ingestion-job.yaml
@@ -6,10 +6,31 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: demo-serviceaccount
+      initContainers:
+        - name: wait-for-nifi
+          image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              echo 'Waiting for NiFi to be created'
+              kubectl wait --for=create pod/nifi-node-default-0 --timeout=30m
+              echo 'Waiting for NiFi to be ready'
+              kubectl wait --for=condition=Ready pod/nifi-node-default-0 --timeout=30m
       containers:
         - name: create-nifi-ingestion-job
           image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
-          command: ["bash", "-c", "curl -O https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-water-level-data/IngestWaterLevelsToKafka.xml && python -u /tmp/script/script.py"]
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              curl -O https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-water-level-data/IngestWaterLevelsToKafka.xml
+              python -u /tmp/script/script.py
           volumeMounts:
             - name: script
               mountPath: /tmp/script

--- a/demos/nifi-kafka-druid-water-level-data/serviceaccount.yaml
+++ b/demos/nifi-kafka-druid-water-level-data/serviceaccount.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: demo-serviceaccount
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: demo-clusterrolebinding
+subjects:
+  - kind: ServiceAccount
+    name: demo-serviceaccount
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: demo-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: demo-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create

--- a/demos/nifi-kafka-druid-water-level-data/setup-superset.yaml
+++ b/demos/nifi-kafka-druid-water-level-data/setup-superset.yaml
@@ -6,10 +6,31 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: demo-serviceaccount
+      initContainers:
+        - name: wait-for-superset
+          image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              echo 'Waiting for Superset to be created'
+              kubectl wait --for=create pod/superset-node-default-0 --timeout=30m
+              echo 'Waiting for Superset to be ready'
+              kubectl wait --for=condition=Ready pod/superset-node-default-0 --timeout=30m
       containers:
         - name: setup-superset
           image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
-          command: ["bash", "-c", "curl -o superset-assets.zip https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-water-level-data/superset-assets.zip && python -u /tmp/script/script.py"]
+          command:
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              curl -o superset-assets.zip https://raw.githubusercontent.com/stackabletech/demos/main/demos/nifi-kafka-druid-water-level-data/superset-assets.zip
+              python -u /tmp/script/script.py
           volumeMounts:
             - name: script
               mountPath: /tmp/script

--- a/demos/signal-processing/Dockerfile-nifi
+++ b/demos/signal-processing/Dockerfile-nifi
@@ -1,4 +1,4 @@
-FROM oci.stackable.tech/sdp/nifi:2.2.0-stackable0.0.0-dev
+FROM oci.stackable.tech/sdp/nifi:1.28.1-stackable0.0.0-dev
 
 # This is the postgresql JDBC driver from https://jdbc.postgresql.org/download/
 # There appear to be no signatures to validate against 😬
@@ -8,5 +8,6 @@ FROM oci.stackable.tech/sdp/nifi:2.2.0-stackable0.0.0-dev
 # curl --fail -u "your_username" --upload-file "postgresql-$VERSION.jar" 'https://repo.stackable.tech/repository/misc/jdbc/'
 # rm "postgresql-$VERSION.jar"
 
+# IMPORTANT (@NickLarsenNZ): Changing this version requires a change in the NiFi template (DownloadAndWriteToDB.xml)
 ARG DRIVER_VERSION="42.7.5"
 RUN curl --fail -o "/stackable/nifi/postgresql-$DRIVER_VERSION.jar" "https://repo.stackable.tech/repository/misc/jdbc/postgresql-$DRIVER_VERSION.jar"

--- a/demos/signal-processing/Dockerfile-nifi
+++ b/demos/signal-processing/Dockerfile-nifi
@@ -1,3 +1,12 @@
-FROM oci.stackable.tech/sdp/nifi:1.27.0-stackable0.0.0-dev
+FROM oci.stackable.tech/sdp/nifi:2.2.0-stackable0.0.0-dev
 
-RUN curl --fail -o /stackable/nifi/postgresql-42.6.0.jar "https://repo.stackable.tech/repository/misc/postgresql-timescaledb/postgresql-42.6.0.jar"
+# This is the postgresql JDBC driver from https://jdbc.postgresql.org/download/
+# There appear to be no signatures to validate against 😬
+#
+# VERSION="42.7.5"
+# curl -O "https://jdbc.postgresql.org/download/postgresql-$VERSION.jar"
+# curl --fail -u "your_username" --upload-file "postgresql-$VERSION.jar" 'https://repo.stackable.tech/repository/misc/jdbc/'
+# rm "postgresql-$VERSION.jar"
+
+ARG DRIVER_VERSION="42.7.5"
+RUN curl --fail -o "/stackable/nifi/postgresql-$DRIVER_VERSION.jar" "https://repo.stackable.tech/repository/misc/jdbc/postgresql-$DRIVER_VERSION.jar"

--- a/demos/signal-processing/DownloadAndWriteToDB.xml
+++ b/demos/signal-processing/DownloadAndWriteToDB.xml
@@ -189,7 +189,7 @@
                 </entry>
                 <entry>
                     <key>database-driver-locations</key>
-                    <value>/stackable/nifi/postgresql-42.6.0.jar</value>
+                    <value>/stackable/nifi/postgresql-42.7.5.jar</value>
                 </entry>
                 <entry>
                     <key>kerberos-user-service</key>

--- a/demos/signal-processing/create-nifi-ingestion-job.yaml
+++ b/demos/signal-processing/create-nifi-ingestion-job.yaml
@@ -12,12 +12,18 @@ spec:
           image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
           command:
             - bash
-            - -c
             - -euo
             - pipefail
+            - -c
             - |
-              echo 'Waiting for timescaleDB tables to be ready'
+              echo 'Waiting for timescaleDB job to be created'
+              until kubectl get job create-timescale-tables-job 2>/dev/null; do sleep 5; done
+              kubectl wait --for=create job/create-timescale-tables-job --timeout=30m
+              echo 'Waiting for timescaleDB job to be completed'
               kubectl wait --for=condition=complete job/create-timescale-tables-job --timeout=30m
+
+              echo 'Waiting for NiFi to be created'
+              kubectl wait --for=create pod/nifi-node-default-0 --timeout=30m
               echo 'Waiting for NiFi to be ready'
               kubectl wait --for=condition=Ready pod/nifi-node-default-0 --timeout=30m
       containers:
@@ -25,9 +31,9 @@ spec:
           image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           command:
             - bash
-            - -c
             - -euo
             - pipefail
+            - -c
             - |
               export PGPASSWORD=$(cat /timescale-admin-credentials/password)
               curl -O https://raw.githubusercontent.com/stackabletech/demos/main/demos/signal-processing/DownloadAndWriteToDB.xml

--- a/demos/signal-processing/create-nifi-ingestion-job.yaml
+++ b/demos/signal-processing/create-nifi-ingestion-job.yaml
@@ -10,16 +10,28 @@ spec:
       initContainers:
         - name: wait-for-timescale-job
           image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
-          command: ["bash", "-c", "echo 'Waiting for timescaleDB tables to be ready'
-                    && kubectl wait --for=condition=complete job/create-timescale-tables-job"
-                  ]
+          command:
+            - bash
+            - -c
+            - -euo
+            - pipefail
+            - |
+                echo 'Waiting for timescaleDB tables and NiFi to be ready'
+                kubectl wait --for=condition=complete job/create-timescale-tables-job --timeout=300s
+                kubectl wait --for=condition=Ready pod/nifi-node-default-0 --timeout=300s
       containers:
         - name: create-nifi-ingestion-job
           image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
-          command: ["bash", "-c", "export PGPASSWORD=$(cat /timescale-admin-credentials/password) && \
-            curl -O https://raw.githubusercontent.com/stackabletech/demos/main/demos/signal-processing/DownloadAndWriteToDB.xml && \
-            sed -i \"s/PLACEHOLDERPGPASSWORD/$PGPASSWORD/g\" DownloadAndWriteToDB.xml && \
-            python -u /tmp/script/script.py"]
+          command:
+            - bash
+            - -c
+            - -euo
+            - pipefail
+            - |
+                export PGPASSWORD=$(cat /timescale-admin-credentials/password)
+                curl -O https://raw.githubusercontent.com/stackabletech/demos/main/demos/signal-processing/DownloadAndWriteToDB.xml
+                sed -i "s/PLACEHOLDERPGPASSWORD/$PGPASSWORD/g" DownloadAndWriteToDB.xml
+                python -u /tmp/script/script.py
           volumeMounts:
             - name: script
               mountPath: /tmp/script
@@ -70,11 +82,12 @@ data:
     nipyapi.config.nifi_config.host = f"{ENDPOINT}/nifi-api"
     nipyapi.config.nifi_config.verify_ssl = False
 
-    print("Logging in")
+    print(f"Logging in as {USERNAME}")
     service_login(username=USERNAME, password=PASSWORD)
     print("Logged in")
 
     pg_id = get_root_pg_id()
+    print(f"pgid={pg_id}")
 
     upload_template(pg_id, TEMPLATE_FILE)
 

--- a/demos/signal-processing/create-nifi-ingestion-job.yaml
+++ b/demos/signal-processing/create-nifi-ingestion-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       serviceAccountName: demo-serviceaccount
       initContainers:
-        - name: wait-for-timescale-job
+        - name: wait-for-timescale-job-and-nifi
           image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
           command:
             - bash
@@ -16,9 +16,10 @@ spec:
             - -euo
             - pipefail
             - |
-                echo 'Waiting for timescaleDB tables and NiFi to be ready'
-                kubectl wait --for=condition=complete job/create-timescale-tables-job --timeout=300s
-                kubectl wait --for=condition=Ready pod/nifi-node-default-0 --timeout=300s
+              echo 'Waiting for timescaleDB tables to be ready'
+              kubectl wait --for=condition=complete job/create-timescale-tables-job --timeout=30m
+              echo 'Waiting for NiFi to be ready'
+              kubectl wait --for=condition=Ready pod/nifi-node-default-0 --timeout=30m
       containers:
         - name: create-nifi-ingestion-job
           image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
@@ -28,10 +29,10 @@ spec:
             - -euo
             - pipefail
             - |
-                export PGPASSWORD=$(cat /timescale-admin-credentials/password)
-                curl -O https://raw.githubusercontent.com/stackabletech/demos/main/demos/signal-processing/DownloadAndWriteToDB.xml
-                sed -i "s/PLACEHOLDERPGPASSWORD/$PGPASSWORD/g" DownloadAndWriteToDB.xml
-                python -u /tmp/script/script.py
+              export PGPASSWORD=$(cat /timescale-admin-credentials/password)
+              curl -O https://raw.githubusercontent.com/stackabletech/demos/main/demos/signal-processing/DownloadAndWriteToDB.xml
+              sed -i "s/PLACEHOLDERPGPASSWORD/$PGPASSWORD/g" DownloadAndWriteToDB.xml
+              python -u /tmp/script/script.py
           volumeMounts:
             - name: script
               mountPath: /tmp/script

--- a/demos/signal-processing/create-timescale-tables.yaml
+++ b/demos/signal-processing/create-timescale-tables.yaml
@@ -12,20 +12,23 @@ spec:
           image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
           command:
             - bash
-            - -c
             - -euo
             - pipefail
+            - -c
             - |
+              echo 'Waiting for timescaleDB to be created'
+              kubectl wait --for=create pod/postgresql-timescaledb-0 --timeout=30m
+
               echo 'Waiting for timescaleDB to be ready'
-              kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=postgresql-timescaledb --timeout=30m
+              kubectl wait --for=condition=ready pod/postgresql-timescaledb-0 --timeout=30m
       containers:
         - name: create-timescale-tables-job
           image: postgres
           command:
             - bash
-            - -c
             - -euo
             - pipefail
+            - -c
             - |
               export PGPASSWORD=$(cat /timescale-admin-credentials/password)
               echo 'Submitting DDL...'

--- a/demos/signal-processing/create-timescale-tables.yaml
+++ b/demos/signal-processing/create-timescale-tables.yaml
@@ -10,17 +10,37 @@ spec:
       initContainers:
         - name: wait-for-timescale
           image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
-          command: ["bash", "-c", "echo 'Waiting for timescaleDB to be ready'
-                    && kubectl wait --for=condition=ready --timeout=30m pod -l app.kubernetes.io/name=postgresql-timescaledb"
-                  ]
+          command:
+            - bash
+            - -c
+            - -euo
+            - pipefail
+            - |
+              echo 'Waiting for timescaleDB to be ready'
+              kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=postgresql-timescaledb --timeout=30m
       containers:
         - name: create-timescale-tables-job
           image: postgres
-          command: ["bash", "-c", "export PGPASSWORD=$(cat /timescale-admin-credentials/password) && \
-            echo 'Submitting DDL...' && \
-            psql -U admin -h postgresql-timescaledb.default.svc.cluster.local postgres -c '\\x' -c 'CREATE DATABASE tsdb' -c '\\c tsdb' -f /tmp/sql/timescaledb.sql -c 'select count(*) from conditions' -c '\\q' && \
-            echo 'Creating extension as superuser...' && \
-            psql -U postgres -h postgresql-timescaledb.default.svc.cluster.local postgres -c '\\x' -c '\\c tsdb' -c 'CREATE EXTENSION timescaledb_toolkit' -c '\\q'"]
+          command:
+            - bash
+            - -c
+            - -euo
+            - pipefail
+            - |
+              export PGPASSWORD=$(cat /timescale-admin-credentials/password)
+              echo 'Submitting DDL...'
+              psql -U admin -h postgresql-timescaledb.default.svc.cluster.local postgres \
+                -c '\x' -c 'CREATE DATABASE tsdb' \
+                -c '\c tsdb' \
+                -f /tmp/sql/timescaledb.sql \
+                -c 'select count(*) from conditions' \
+                -c '\q'
+              echo 'Creating extension as superuser...'
+              psql -U postgres -h postgresql-timescaledb.default.svc.cluster.local postgres \
+                -c '\x' \
+                -c '\c tsdb' \
+                -c 'CREATE EXTENSION timescaledb_toolkit' \
+                -c '\q'
           volumeMounts:
             - name: script
               mountPath: /tmp/sql

--- a/docs/modules/demos/pages/signal-processing.adoc
+++ b/docs/modules/demos/pages/signal-processing.adoc
@@ -138,14 +138,14 @@ There are two located in the "Stackable Data Platform" folder.
 
 === Measurements
 
-This is the original data. The first graph plots two measurments (`r1`, `r2`), together with the model scores (`r1_score`, `r2_score`, `r1_score_lttb`).#
+The _Gas measurements_ dashboard shows the original data. The first graph plots two measurments (`r1`, `r2`), together with the model scores (`r1_score`, `r2_score`, `r1_score_lttb`).#
 These are superimposed on each other for ease of comparison.
 
 image::signal-processing/measurements.png[]
 
 === Predictions
 
-In this second dashboard the predictions for all r-values are plotted: the top graph takes an average across all measurements, with a threshold marked as a red line across the top.
+The _Spectral Residuals_ dashboard shows the predictions for all r-values are plotted: the top graph takes an average across all measurements, with a threshold marked as a red line across the top.
 This can be used for triggering email alerts.
 Underneath the individual r-values are plotted, firstly as raw data and then the same using downsampling.
 Downsampling uses a built-in Timescale extension to significantly reduce the number of data plotted while retaining the same overall shape.

--- a/stacks/data-lakehouse-iceberg-trino-spark/nifi.yaml
+++ b/stacks/data-lakehouse-iceberg-trino-spark/nifi.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nifi
 spec:
   image:
-    productVersion: 2.2.0
+    productVersion: 1.28.1
   clusterConfig:
     authentication:
       - authenticationClass: nifi-admin-credentials

--- a/stacks/data-lakehouse-iceberg-trino-spark/nifi.yaml
+++ b/stacks/data-lakehouse-iceberg-trino-spark/nifi.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nifi
 spec:
   image:
-    productVersion: 1.27.0
+    productVersion: 2.2.0
   clusterConfig:
     authentication:
       - authenticationClass: nifi-admin-credentials

--- a/stacks/nifi-kafka-druid-superset-s3/nifi.yaml
+++ b/stacks/nifi-kafka-druid-superset-s3/nifi.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nifi
 spec:
   image:
-    productVersion: 2.2.0
+    productVersion: 1.28.1
   clusterConfig:
     authentication:
       - authenticationClass: nifi-admin-credentials

--- a/stacks/nifi-kafka-druid-superset-s3/nifi.yaml
+++ b/stacks/nifi-kafka-druid-superset-s3/nifi.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nifi
 spec:
   image:
-    productVersion: 1.27.0
+    productVersion: 2.2.0
   clusterConfig:
     authentication:
       - authenticationClass: nifi-admin-credentials

--- a/stacks/signal-processing/nifi.yaml
+++ b/stacks/signal-processing/nifi.yaml
@@ -5,10 +5,10 @@ metadata:
   name: nifi
 spec:
   image:
-    productVersion: 1.27.0
+    productVersion: 2.2.0
     # TODO (@NickLarsenNZ): Use a versioned image with stackable0.0.0-dev or stackableXX.X.X so that
     # the demo is reproducable for the release and it will be automatically replaced for the release branch.
-    custom: oci.stackable.tech/stackable/nifi:1.27.0-postgresql
+    custom: oci.stackable.tech/stackable/nifi:2.2.0-postgresql
   clusterConfig:
     listenerClass: external-unstable
     zookeeperConfigMapName: nifi-znode

--- a/stacks/signal-processing/nifi.yaml
+++ b/stacks/signal-processing/nifi.yaml
@@ -20,13 +20,6 @@ spec:
       keySecret: nifi-sensitive-property-key
       autoGenerate: true
   nodes:
-    podOverrides:
-      metadata:
-        annotations:
-          sidecar.opentelemetry.io/inject: "default/otel-collector-grpc"
-          instrumentation.opentelemetry.io/inject-java: "true"
-          # Todo: We probably want to add the following annotation by default.
-          instrumentation.opentelemetry.io/java-container-names: "nifi"
     config:
       resources:
         cpu:

--- a/stacks/signal-processing/nifi.yaml
+++ b/stacks/signal-processing/nifi.yaml
@@ -5,10 +5,12 @@ metadata:
   name: nifi
 spec:
   image:
-    productVersion: 2.2.0
+    productVersion: 1.28.1
     # TODO (@NickLarsenNZ): Use a versioned image with stackable0.0.0-dev or stackableXX.X.X so that
     # the demo is reproducable for the release and it will be automatically replaced for the release branch.
-    custom: oci.stackable.tech/stackable/nifi:2.2.0-postgresql
+    # custom: oci.stackable.tech/stackable/nifi:2.2.0-postgresql
+    custom: oci.stackable.tech/stackable/nifi:1.28.1-postgresql
+    # pullPolicy: IfNotPresent
   clusterConfig:
     listenerClass: external-unstable
     zookeeperConfigMapName: nifi-znode
@@ -18,6 +20,13 @@ spec:
       keySecret: nifi-sensitive-property-key
       autoGenerate: true
   nodes:
+    podOverrides:
+      metadata:
+        annotations:
+          sidecar.opentelemetry.io/inject: "default/otel-collector-grpc"
+          instrumentation.opentelemetry.io/inject-java: "true"
+          # Todo: We probably want to add the following annotation by default.
+          instrumentation.opentelemetry.io/java-container-names: "nifi"
     config:
       resources:
         cpu:


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/966.

- Update NiFi demos and custom image to 1.28.1
- Update the postgres jar and move it to a more appropriate image repository (it is not related to timescale).
- Update the docs to explain which dashboard is being described.
- Improve readability of the initialisation jobs.

> [!IMPORTANT]
> Despite the branch name, we are not bumping the demos to 2.2.0 as they rely on uploading templates.

### Testing

- [x] signal-processing
- [x] nifi-kafka-druid-earthquake-data
- [x] nifi-kafka-druid-water-level-data