### PR TITLE
fix: Demo/Stack URLs for JupyterHub-Keycloak demo

### DIFF
--- a/demos/demos-v2.yaml
+++ b/demos/demos-v2.yaml
@@ -236,8 +236,7 @@ demos:
       - spark
       - S3
     manifests:
-      # TODO: revert paths
-      - plainYaml: demos/jupyterhub-keycloak/load-gas-data.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/demos/jupyterhub-keycloak/load-gas-data.yaml
     supportedNamespaces: []
     resourceRequests:
       cpu: 6400m

--- a/stacks/jupyterhub-keycloak/jupyterhub.yaml
+++ b/stacks/jupyterhub-keycloak/jupyterhub.yaml
@@ -149,7 +149,7 @@ options:
     initContainers:
       - name: download-notebook
         image: oci.stackable.tech/sdp/tools:1.0.0-stackable0.0.0-dev
-        command: ['sh', '-c', 'curl https://raw.githubusercontent.com/stackabletech/demos/feat/keycloak-jupyterhub/stacks/jupyterhub-keycloak/process-s3.ipynb -o /notebook/process-s3.ipynb']
+        command: ['sh', '-c', 'curl https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-keycloak/process-s3.ipynb -o /notebook/process-s3.ipynb']
         volumeMounts:
           - mountPath: /notebook
             name: notebook

--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -666,14 +666,13 @@ stacks:
       memory: 9010Mi
       pvc: 24Gi
     manifests:
-      # TODO: revert paths
-      - helmChart: stacks/_templates/minio.yaml
-      - plainYaml: stacks/jupyterhub-keycloak/keycloak-serviceaccount.yaml
-      - plainYaml: stacks/jupyterhub-keycloak/keycloak-realm-config.yaml
-      - plainYaml: stacks/jupyterhub-keycloak/keycloak.yaml
-      - helmChart: stacks/jupyterhub-keycloak/jupyterhub.yaml
-      - plainYaml: stacks/jupyterhub-keycloak/serviceaccount.yaml
-      - plainYaml: stacks/jupyterhub-keycloak/s3-connection.yaml
+      - helmChart: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/_templates/minio.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-keycloak/keycloak-serviceaccount.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-keycloak/keycloak-realm-config.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-keycloak/keycloak.yaml
+      - helmChart: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-keycloak/jupyterhub.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-keycloak/serviceaccount.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-keycloak/s3-connection.yaml
     parameters:
       - name: keycloakAdminPassword
         description: Password of the Keycloak admin user


### PR DESCRIPTION
These paths were not re-set following the merge of the demo.