### PR TITLE
chore: Update HDFS to 3.4.1

### DIFF
--- a/demos/jupyterhub-pyspark-hdfs-anomaly-detection-taxi-data/load-test-data.yaml
+++ b/demos/jupyterhub-pyspark-hdfs-anomaly-detection-taxi-data/load-test-data.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: load-ny-taxi-data
-          image: oci.stackable.tech/sdp/hadoop:3.4.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/hadoop:3.4.1-stackable0.0.0-dev
           # yamllint disable rule:line-length
           command: ["bash", "-c", "/stackable/hadoop/bin/hdfs dfs -mkdir -p /ny-taxi-data/raw \
           && cd /tmp \

--- a/stacks/dual-hive-hdfs-s3/hdfs.yaml
+++ b/stacks/dual-hive-hdfs-s3/hdfs.yaml
@@ -25,7 +25,7 @@ metadata:
   name: hdfs
 spec:
   image:
-    productVersion: 3.4.0
+    productVersion: 3.4.1
   clusterConfig:
     listenerClass: external-unstable
     dfsReplication: 1

--- a/stacks/end-to-end-security/hdfs.yaml
+++ b/stacks/end-to-end-security/hdfs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hdfs
 spec:
   image:
-    productVersion: 3.4.0
+    productVersion: 3.4.1
   clusterConfig:
     zookeeperConfigMapName: hdfs-znode
     authentication:

--- a/stacks/hdfs-hbase/hdfs.yaml
+++ b/stacks/hdfs-hbase/hdfs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hdfs
 spec:
   image:
-    productVersion: 3.4.0
+    productVersion: 3.4.1
   clusterConfig:
     dfsReplication: 1
     zookeeperConfigMapName: hdfs-znode

--- a/stacks/jupyterhub-pyspark-hdfs/hdfs.yaml
+++ b/stacks/jupyterhub-pyspark-hdfs/hdfs.yaml
@@ -13,7 +13,7 @@ metadata:
   name: hdfs
 spec:
   image:
-    productVersion: 3.4.0
+    productVersion: 3.4.1
   clusterConfig:
     dfsReplication: 1
     zookeeperConfigMapName: hdfs-znode

--- a/stacks/keycloak-opa-poc/hdfs.yaml
+++ b/stacks/keycloak-opa-poc/hdfs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hdfs
 spec:
   image:
-    productVersion: 3.4.0
+    productVersion: 3.4.1
   clusterConfig:
     dfsReplication: 1
     zookeeperConfigMapName: hdfs-znode


### PR DESCRIPTION
part of https://github.com/stackabletech/docker-images/issues/1018

- I did not touch a 3.3.6-stackable24.7 image (cycling data, not available anymore)
- there are some 3.3.4 references but used for spark