### PR TITLE
fix(backport): E2E Security demo - Separate DB setup from superset resource

### DIFF
--- a/stacks/end-to-end-security/rbac.yaml
+++ b/stacks/end-to-end-security/rbac.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: superset-job-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: superset-job-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: superset-job-role
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch

--- a/stacks/end-to-end-security/setup-postgresql.yaml
+++ b/stacks/end-to-end-security/setup-postgresql.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: setup-db-job
+spec:
+  template:
+    spec:
+      initContainers:
+        # The postgres image does not contain curl or wget...
+        - name: download-dump
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable24.11.1
+          command:
+            - bash
+            - -c
+            - |
+              kubectl rollout status --watch statefulset/postgresql-superset
+              cd /tmp
+              curl --fail -O https://raw.githubusercontent.com/stackabletech/demos/release-24.11/stacks/end-to-end-security/postgres_superset_dump.sql.gz
+              gunzip postgres_superset_dump.sql.gz
+
+              # We need to omit changing the users password, as otherwise the content in the Secrets does not match
+              # the actual password in Postgres.
+              grep -vwE '(CREATE ROLE postgres;|CREATE ROLE superset;|ALTER ROLE postgres|ALTER ROLE superset)' postgres_superset_dump.sql > /dump/postgres_superset_dump.sql
+          volumeMounts:
+            - name: dump
+              mountPath: /dump/
+      containers:
+        - name: restore-postgres
+          image: docker.io/bitnami/postgresql:16.1.0-debian-11-r11 # Same image as the bitnami postgres helm-chart is using
+          command:
+            - bash
+            - -c
+            - |
+              echo "Preparing restore..."
+              psql --host postgresql-superset --user postgres < /dump/postgres_superset_dump.sql
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-superset
+                  key: postgres-password
+          volumeMounts:
+            - name: dump
+              mountPath: /dump/
+      volumes:
+        - name: dump
+          emptyDir: {}
+      restartPolicy: OnFailure
+  backoffLimit: 20

--- a/stacks/end-to-end-security/superset.yaml
+++ b/stacks/end-to-end-security/superset.yaml
@@ -21,49 +21,14 @@ spec:
         replicas: 1
     podOverrides:
       spec:
-        # We need to restore the postgres state before the superset container itself starts some database migrations
         initContainers:
-          # The postgres image does not contain curl or wget...
-          - name: download-dump
-            image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable24.11.1
+          - name: wait-for-setup-db-job
+            image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable24.11.1
             command:
               - bash
               - -c
               - |
-                cd /tmp
-                curl --fail -O https://raw.githubusercontent.com/stackabletech/demos/release-24.11/stacks/end-to-end-security/postgres_superset_dump.sql.gz
-                gunzip postgres_superset_dump.sql.gz
-
-                # We need to omit changing the users password, as otherwise the content in the Secrets does not match
-                # the actual password in Postgres.
-                grep -vwE '(CREATE ROLE postgres;|CREATE ROLE superset;|ALTER ROLE postgres|ALTER ROLE superset)' postgres_superset_dump.sql > /dump/postgres_superset_dump.sql
-            volumeMounts:
-              - name: dump
-                mountPath: /dump/
-          - name: restore-postgres
-            image: docker.io/bitnami/postgresql:16.1.0-debian-11-r11 # Same image as the bitnami postgres helm-chart is using
-            command:
-              - bash
-              - -c
-              - |
-                if psql --host postgresql-superset --user postgres --csv -c "SELECT datname FROM pg_database where datname = 'superset' limit 1" | grep -q superset; then
-                  # The flask app will do any necesary migrations.
-                  echo "Skip restoring the DB as it already exists"
-                  exit 0
-                fi
-                psql --host postgresql-superset --user postgres < /dump/postgres_superset_dump.sql
-            env:
-              - name: PGPASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: postgresql-superset
-                    key: postgres-password
-            volumeMounts:
-              - name: dump
-                mountPath: /dump/
-        volumes:
-          - name: dump
-            emptyDir: {}
+                kubectl wait --for=condition=complete job/setup-db-job
 ---
 apiVersion: v1
 kind: Secret

--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -582,6 +582,8 @@ stacks:
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/release-24.11/stacks/end-to-end-security/trino.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/release-24.11/stacks/end-to-end-security/trino-regorules.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/release-24.11/stacks/end-to-end-security/trino-policies.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/release-24.11/stacks/end-to-end-security/rbac.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/release-24.11/stacks/end-to-end-security/setup-postgresql.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/release-24.11/stacks/end-to-end-security/superset.yaml
     parameters:
       - name: keycloakAdminPassword


### PR DESCRIPTION
Backport of https://github.com/stackabletech/demos/pull/151

Currently `stackablectl demo in end-to-end-security` is broken, this PR fixes that.
Adjusted the commit to the correct versions and branches