### PR TITLE
airflow-scheduled-job: increase scheduler memory limit

### DIFF
--- a/docs/modules/demos/pages/airflow-scheduled-job.adoc
+++ b/docs/modules/demos/pages/airflow-scheduled-job.adoc
@@ -19,7 +19,7 @@ This demo should not be run alongside other demos.
 To run this demo, your system needs at least:
 
 * 2.5 https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#cpu[cpu units] (core/hyperthread)
-* 9GiB memory
+* 10GiB memory
 * 24GiB disk storage
 
 == Overview

--- a/stacks/airflow/airflow.yaml
+++ b/stacks/airflow/airflow.yaml
@@ -33,7 +33,7 @@ spec:
           min: 400m
           max: "1"
         memory:
-          limit: 1Gi
+          limit: 2Gi
       gracefulShutdownTimeout: 30s
     roleGroups:
       default:


### PR DESCRIPTION
fixes OOM kills with 2.10.4 in airflow-scheduled-job