### PR TITLE
fix(stack/trino-superset-s3): Use FQDN for minio, restrict to default namespace

### DIFF
--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -305,7 +305,7 @@ stacks:
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/trino-superset-s3/hive-metastore.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/trino-superset-s3/trino.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/trino-superset-s3/superset.yaml
-    supportedNamespaces: []
+    supportedNamespaces: [default] # until namespace can be templates, the minio FQDN hard-codes the namespace
     resourceRequests:
       cpu: 6800m
       memory: 15822Mi

--- a/stacks/trino-superset-s3/s3-connection.yaml
+++ b/stacks/trino-superset-s3/s3-connection.yaml
@@ -4,7 +4,7 @@ kind: S3Connection
 metadata:
   name: minio
 spec:
-  host: minio
+  host: minio.default.svc.cluster.local
   port: 9000
   accessStyle: Path
   credentials:


### PR DESCRIPTION
Fixes problems where Trino fails to connect to Minio due to TLS subject name verification.