### PR TITLE
fix(end-to-end-security): Downgrade Hive metastore to 4.0.0 (#189)

### DIFF
--- a/stacks/end-to-end-security/hive-metastore.yaml
+++ b/stacks/end-to-end-security/hive-metastore.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hive-iceberg
 spec:
   image:
-    productVersion: 4.0.1
+    productVersion: 4.0.0
   clusterConfig:
     database:
       connString: jdbc:postgresql://postgresql-hive-iceberg:5432/hive


### PR DESCRIPTION
Use hive 4.0.0 instead of 4.0.1, came up during https://github.com/stackabletech/demos/issues/187, cherry-picked from the `release-25.3` branch into main.