### PR TITLE
feat(nifi): Restore flows directly from JSON file instead of using versioning

### DIFF
--- a/demos/data-lakehouse-iceberg-trino-spark/create-nifi-ingestion-job.yaml
+++ b/demos/data-lakehouse-iceberg-trino-spark/create-nifi-ingestion-job.yaml
@@ -50,6 +50,7 @@ data:
     from nipyapi.security import service_login
     import nipyapi
     import os
+    import requests
     import urllib3
 
     # As of 2022-08-29 we cant use "https://nifi:8443" here because <h2>The request contained an invalid host header [<code>nifi:8443</code>] in the request [<code>/nifi-api</code>]. Check for request manipulation or third-party intercept.</h2>
@@ -66,70 +67,36 @@ data:
     service_login(username=USERNAME, password=PASSWORD)
     print("Logged in")
 
-    organization = "stackabletech"
-    repository = "demos"
-    branch = "main"
-    version = "main"
-    directory = "demos/data-lakehouse-iceberg-trino-spark"
-    flow_name = "LakehouseKafkaIngest"
+    response = requests.get("https://raw.githubusercontent.com/stackabletech/demos/refs/heads/main/demos/data-lakehouse-iceberg-trino-spark/LakehouseKafkaIngest.json")
 
-    # Check if the GitHub flow registry client already exists
-    flow_registry_clients = nipyapi.nifi.ControllerApi().get_flow_registry_clients().registries
-
-    github_client = None
-    for client in flow_registry_clients:
-        if client.component.name == "GitHubFlowRegistryClient":
-            github_client = client
-            print("Found existing GitHub flow registry client")
-            break
-
-    if not github_client:
-        print("Creating new GitHub flow registry client")
-        github_client = nipyapi.nifi.ControllerApi().create_flow_registry_client(
-            body={
-                "revision": {"version": 0},
-                "component": {
-                    "name": "GitHubFlowRegistryClient",
-                    "type": "org.apache.nifi.github.GitHubFlowRegistryClient",
-                    "properties": {
-                        "Repository Owner": organization,
-                        "Repository Name": repository,
-                    },
-                    "bundle": {
-                        "group": "org.apache.nifi",
-                        "artifact": "nifi-github-nar",
-                        "version": "2.2.0",
-                    },
-                },
-            }
-        )
+    filename = "/tmp/LakehouseKafkaIngest.json"
+    with open(filename, "wb") as f:
+        f.write(response.content)
 
     pg_id = get_root_pg_id()
 
-    try:
-        # Create process group from the file in the Git repo
-        nipyapi.nifi.ProcessGroupsApi().create_process_group(
-            id=pg_id,
-            body={
-                "revision": {"version": 0},
-                "component": {
-                    "position": {"x": 300, "y": 10},
-                    "versionControlInformation": {
-                        "registryId": github_client.component.id,
-                        "flowId": flow_name,
-                        "bucketId": directory,
-                        "branch": branch,
-                        "version": version,
-                    },
-                },
-            },
-        )
-    except ValueError as e:
-        # Ignore, because nipyapi can't handle non-int versions yet
-        if "invalid literal for int() with base 10" in str(e):
-            print("Ignoring ValueError")
-        else:
-            raise e
+    if not nipyapi.config.nifi_config.api_client:
+        nipyapi.config.nifi_config.api_client = ApiClient()
+
+    header_params = {}
+    header_params['Accept'] = nipyapi.config.nifi_config.api_client.select_header_accept(['application/json'])
+    header_params['Content-Type'] = nipyapi.config.nifi_config.api_client.select_header_content_type(['multipart/form-data'])
+
+    nipyapi.config.nifi_config.api_client.call_api('/process-groups/{pg_id}/process-groups/upload', 'POST',
+        path_params={'pg_id': pg_id},
+        header_params=header_params,
+        _return_http_data_only=True,
+        post_params=[
+            ('id', pg_id),
+            ('groupName', 'LakehouseKafkaIngest'),
+            ('positionX', 100),
+            ('positionY', 10),
+            ('clientId', nipyapi.nifi.FlowApi().generate_client_id()),
+        ],
+        files={
+            'file': filename
+        },
+        auth_settings=['tokenAuth'])
 
     # Scheduling the `Kafka3ConnectionService` fails, if it is started before `StandardRestrictedSSLContextService`, since it depends on it
     # To work around this, we try to schedule the controllers multiple times

--- a/demos/nifi-kafka-druid-earthquake-data/create-nifi-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-earthquake-data/create-nifi-ingestion-job.yaml
@@ -59,6 +59,7 @@ data:
     from nipyapi.security import service_login
     import nipyapi
     import os
+    import requests
     import urllib3
 
     # As of 2022-08-29 we cant use "https://nifi:8443" here because <h2>The request contained an invalid host header [<code>nifi:8443</code>] in the request [<code>/nifi-api</code>]. Check for request manipulation or third-party intercept.</h2>
@@ -75,70 +76,35 @@ data:
     service_login(username=USERNAME, password=PASSWORD)
     print("Logged in")
 
-    organization = "stackabletech"
-    repository = "demos"
-    branch = "main"
-    version = "main"
-    directory = "demos/nifi-kafka-druid-earthquake-data"
-    flow_name = "IngestEarthquakesToKafka"
-
-    # Check if the GitHub flow registry client already exists
-    flow_registry_clients = nipyapi.nifi.ControllerApi().get_flow_registry_clients().registries
-
-    github_client = None
-    for client in flow_registry_clients:
-        if client.component.name == "GitHubFlowRegistryClient":
-            github_client = client
-            print("Found existing GitHub flow registry client")
-            break
-
-    if not github_client:
-        print("Creating new GitHub flow registry client")
-        github_client = nipyapi.nifi.ControllerApi().create_flow_registry_client(
-            body={
-                "revision": {"version": 0},
-                "component": {
-                    "name": "GitHubFlowRegistryClient",
-                    "type": "org.apache.nifi.github.GitHubFlowRegistryClient",
-                    "properties": {
-                        "Repository Owner": organization,
-                        "Repository Name": repository,
-                    },
-                    "bundle": {
-                        "group": "org.apache.nifi",
-                        "artifact": "nifi-github-nar",
-                        "version": "2.2.0",
-                    },
-                },
-            }
-        )
+    response = requests.get("https://raw.githubusercontent.com/stackabletech/demos/refs/heads/main/demos/nifi-kafka-druid-earthquake-data/IngestEarthquakesToKafka.json")
+    filename = "/tmp/IngestEarthquakesToKafka.json"
+    with open(filename, "wb") as f:
+        f.write(response.content)
 
     pg_id = get_root_pg_id()
 
-    try:
-        # Create process group from the file in the Git repo
-        nipyapi.nifi.ProcessGroupsApi().create_process_group(
-            id=pg_id,
-            body={
-                "revision": {"version": 0},
-                "component": {
-                    "position": {"x": 300, "y": 10},
-                    "versionControlInformation": {
-                        "registryId": github_client.component.id,
-                        "flowId": flow_name,
-                        "bucketId": directory,
-                        "branch": branch,
-                        "version": version,
-                    },
-                },
-            },
-        )
-    except ValueError as e:
-        # Ignore, because nipyapi can't handle non-int versions yet
-        if "invalid literal for int() with base 10" in str(e):
-            print("Ignoring ValueError")
-        else:
-            raise e
+    if not nipyapi.config.nifi_config.api_client:
+        nipyapi.config.nifi_config.api_client = ApiClient()
+
+    header_params = {}
+    header_params['Accept'] = nipyapi.config.nifi_config.api_client.select_header_accept(['application/json'])
+    header_params['Content-Type'] = nipyapi.config.nifi_config.api_client.select_header_content_type(['multipart/form-data'])
+
+    nipyapi.config.nifi_config.api_client.call_api('/process-groups/{pg_id}/process-groups/upload', 'POST',
+        path_params={'pg_id': pg_id},
+        header_params=header_params,
+        _return_http_data_only=True,
+        post_params=[
+            ('id', pg_id),
+            ('groupName', 'IngestEarthquakesToKafka'),
+            ('positionX', 100),
+            ('positionY', 10),
+            ('clientId', nipyapi.nifi.FlowApi().generate_client_id()),
+        ],
+        files={
+            'file': filename
+        },
+        auth_settings=['tokenAuth'])
 
     # Scheduling the `Kafka3ConnectionService` fails, if it is started before `StandardRestrictedSSLContextService`, since it depends on it
     # To work around this, we try to schedule the controllers multiple times

--- a/demos/nifi-kafka-druid-water-level-data/create-nifi-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-water-level-data/create-nifi-ingestion-job.yaml
@@ -59,6 +59,7 @@ data:
     from nipyapi.security import service_login
     import nipyapi
     import os
+    import requests
     import urllib3
 
     # As of 2022-08-29 we cant use "https://nifi:8443" here because <h2>The request contained an invalid host header [<code>nifi:8443</code>] in the request [<code>/nifi-api</code>]. Check for request manipulation or third-party intercept.</h2>
@@ -75,70 +76,36 @@ data:
     service_login(username=USERNAME, password=PASSWORD)
     print("Logged in")
 
-    organization = "stackabletech"
-    repository = "demos"
-    branch = "main"
-    version = "main"
-    directory = "demos/nifi-kafka-druid-water-level-data"
-    flow_name = "IngestWaterLevelsToKafka"
+    response = requests.get("https://raw.githubusercontent.com/stackabletech/demos/refs/heads/main/demos/nifi-kafka-druid-water-level-data/IngestWaterLevelsToKafka.json")
 
-    # Check if the GitHub flow registry client already exists
-    flow_registry_clients = nipyapi.nifi.ControllerApi().get_flow_registry_clients().registries
-
-    github_client = None
-    for client in flow_registry_clients:
-        if client.component.name == "GitHubFlowRegistryClient":
-            github_client = client
-            print("Found existing GitHub flow registry client")
-            break
-
-    if not github_client:
-        print("Creating new GitHub flow registry client")
-        github_client = nipyapi.nifi.ControllerApi().create_flow_registry_client(
-            body={
-                "revision": {"version": 0},
-                "component": {
-                    "name": "GitHubFlowRegistryClient",
-                    "type": "org.apache.nifi.github.GitHubFlowRegistryClient",
-                    "properties": {
-                        "Repository Owner": organization,
-                        "Repository Name": repository,
-                    },
-                    "bundle": {
-                        "group": "org.apache.nifi",
-                        "artifact": "nifi-github-nar",
-                        "version": "2.2.0",
-                    },
-                },
-            }
-        )
+    filename = "/tmp/IngestWaterLevelsToKafka.json"
+    with open(filename, "wb") as f:
+        f.write(response.content)
 
     pg_id = get_root_pg_id()
 
-    try:
-        # Create process group from the file in the Git repo
-        nipyapi.nifi.ProcessGroupsApi().create_process_group(
-            id=pg_id,
-            body={
-                "revision": {"version": 0},
-                "component": {
-                    "position": {"x": 300, "y": 10},
-                    "versionControlInformation": {
-                        "registryId": github_client.component.id,
-                        "flowId": flow_name,
-                        "bucketId": directory,
-                        "branch": branch,
-                        "version": version,
-                    },
-                },
-            },
-        )
-    except ValueError as e:
-        # Ignore, because nipyapi can't handle non-int versions yet
-        if "invalid literal for int() with base 10" in str(e):
-            print("Ignoring ValueError")
-        else:
-            raise e
+    if not nipyapi.config.nifi_config.api_client:
+        nipyapi.config.nifi_config.api_client = ApiClient()
+
+    header_params = {}
+    header_params['Accept'] = nipyapi.config.nifi_config.api_client.select_header_accept(['application/json'])
+    header_params['Content-Type'] = nipyapi.config.nifi_config.api_client.select_header_content_type(['multipart/form-data'])
+
+    nipyapi.config.nifi_config.api_client.call_api('/process-groups/{pg_id}/process-groups/upload', 'POST',
+        path_params={'pg_id': pg_id},
+        header_params=header_params,
+        _return_http_data_only=True,
+        post_params=[
+            ('id', pg_id),
+            ('groupName', 'IngestWaterLevelsToKafka'),
+            ('positionX', 100),
+            ('positionY', 10),
+            ('clientId', nipyapi.nifi.FlowApi().generate_client_id()),
+        ],
+        files={
+            'file': filename
+        },
+        auth_settings=['tokenAuth'])
 
     # Scheduling the `Kafka3ConnectionService` fails, if it is started before `StandardRestrictedSSLContextService`, since it depends on it
     # To work around this, we try to schedule the controllers multiple times

--- a/demos/signal-processing/create-nifi-ingestion-job.yaml
+++ b/demos/signal-processing/create-nifi-ingestion-job.yaml
@@ -70,6 +70,7 @@ data:
     from nipyapi.security import service_login
     import nipyapi
     import os
+    import requests
     import urllib3
 
     # As of 2022-08-29 we cant use "https://nifi:8443" here because <h2>The request contained an invalid host header [<code>nifi:8443</code>] in the request [<code>/nifi-api</code>]. Check for request manipulation or third-party intercept.</h2>
@@ -86,60 +87,36 @@ data:
     service_login(username=USERNAME, password=PASSWORD)
     print("Logged in")
 
-    organization = "stackabletech"
-    repository = "demos"
-    branch = "main"
-    version = "main"
-    directory = "demos/signal-processing"
-    flow_name = "DownloadAndWriteToDB"
+    response = requests.get("https://raw.githubusercontent.com/stackabletech/demos/refs/heads/main/demos/signal-processing/DownloadAndWriteToDB.json")
 
-    # Register the flow registry client
-    response = nipyapi.nifi.ControllerApi().create_flow_registry_client(
-        body={
-            "revision": {"version": 0},
-            "component": {
-                "name": "GitHubFlowRegistryClient",
-                "type": "org.apache.nifi.github.GitHubFlowRegistryClient",
-                "properties": {
-                    "Repository Owner": organization,
-                    "Repository Name": repository,
-                },
-                "bundle": {
-                    "group": "org.apache.nifi",
-                    "artifact": "nifi-github-nar",
-                    "version": "2.2.0",
-                },
-            },
-        }
-    )
+    filename = "/tmp/DownloadAndWriteToDB.json"
+    with open(filename, "wb") as f:
+        f.write(response.content)
 
     pg_id = get_root_pg_id()
-    print(f"pgid={pg_id}")
 
-    try:
-        # Create process group from the file in the Git repo
-        nipyapi.nifi.ProcessGroupsApi().create_process_group(
-            id=pg_id,
-            body={
-                "revision": {"version": 0},
-                "component": {
-                    "position": {"x": 300, "y": 10},
-                    "versionControlInformation": {
-                        "registryId": response.component.id,
-                        "flowId": flow_name,
-                        "bucketId": directory,
-                        "branch": branch,
-                        "version": version,
-                    },
-                },
-            },
-        )
-    except ValueError as e:
-        # Ignore, because nipyapi can't handle non-int versions yet
-        if "invalid literal for int() with base 10" in str(e):
-            print("Ignoring ValueError")
-        else:
-            raise e
+    if not nipyapi.config.nifi_config.api_client:
+        nipyapi.config.nifi_config.api_client = ApiClient()
+
+    header_params = {}
+    header_params['Accept'] = nipyapi.config.nifi_config.api_client.select_header_accept(['application/json'])
+    header_params['Content-Type'] = nipyapi.config.nifi_config.api_client.select_header_content_type(['multipart/form-data'])
+
+    nipyapi.config.nifi_config.api_client.call_api('/process-groups/{pg_id}/process-groups/upload', 'POST',
+        path_params={'pg_id': pg_id},
+        header_params=header_params,
+        _return_http_data_only=True,
+        post_params=[
+            ('id', pg_id),
+            ('groupName', 'DownloadAndWriteToDB'),
+            ('positionX', 100),
+            ('positionY', 10),
+            ('clientId', nipyapi.nifi.FlowApi().generate_client_id()),
+        ],
+        files={
+            'file': filename
+        },
+        auth_settings=['tokenAuth'])
 
     # Update the controller services with the correct password
     for controller in list_all_controllers(pg_id):


### PR DESCRIPTION
While the demos are currently working, NiFi 2 reports a status drift to the versioned components when comparing the deployed state with the state in Git. This is wrong, but we can't really work around it and it might irritate users.
Also, we saw some problems related to Github's rate limits when installing NiFi demos too often on the same machine.

This PR drops the whole process of versioning, since it is not needed for the demos. It was just our first approach as a replacement for the "templates" functionality that was removed with NiFi 2. Instead of using versioning, we now download the JSON files from Github via HTTP and then directly create the Flows via NiFis `/process-groups/upload` API.