### PR TITLE
chore: Bump vector to 0.46.1

### DIFF
--- a/stacks/_templates/vector-aggregator.yaml
+++ b/stacks/_templates/vector-aggregator.yaml
@@ -4,7 +4,7 @@ name: vector
 repo:
   name: vector
   url: https://helm.vector.dev
-version: 0.39.0 # app version 0.43.1
+version: 0.42.1 # app version 0.46.1
 options:
   commonLabels:
     stackable.tech/vendor: Stackable


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1085.

- Bump to Vector 0.46.1 (chart version 0.42.1)