### PR TITLE
ci: Add failure notification job

### DIFF
--- a/.github/workflows/dev_jupyter-pyspark-with-alibi-detect.yaml
+++ b/.github/workflows/dev_jupyter-pyspark-with-alibi-detect.yaml
@@ -19,6 +19,7 @@ jobs:
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_DEMOS_GITHUB_ACTION_BUILD_SECRET }}
+      slack-token: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}
     with:
       image-name: jupyter-pyspark-with-alibi-detect
       # TODO (@NickLarsenNZ): Use a versioned image with stackable0.0.0-dev or stackableXX.X.X so that

--- a/.github/workflows/dev_nifi.yaml
+++ b/.github/workflows/dev_nifi.yaml
@@ -18,6 +18,7 @@ jobs:
     uses: ./.github/workflows/reusable_build_image.yaml
     secrets:
       harbor-robot-secret: ${{ secrets.HARBOR_ROBOT_DEMOS_GITHUB_ACTION_BUILD_SECRET }}
+      slack-token: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}
     with:
       image-name: nifi
       # TODO (@NickLarsenNZ): Use a versioned image with stackable0.0.0-dev or stackableXX.X.X so that

--- a/.github/workflows/reusable_build_image.yaml
+++ b/.github/workflows/reusable_build_image.yaml
@@ -14,6 +14,9 @@ on:
       harbor-robot-secret:
         description: The secret for the Harbor robot user used to push images and manifest
         required: true
+      slack-token:
+        description: The Slack token used to post failure notifications
+        required: true
 
 jobs:
   build:
@@ -79,3 +82,44 @@ jobs:
           image-registry-password: ${{ secrets.harbor-robot-secret }}
           image-repository: demos/${{ env.IMAGE_NAME }}
           image-index-manifest-tag: ${{ env.IMAGE_VERSION }}
+
+  notify:
+    name: Failure Notification
+    needs: [build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: "C07UG6JH44F" # notifications-container-images
+          payload: |
+            {
+              "text": "*${{ github.workflow }}* failed (attempt ${{ github.run_attempt }})",
+              "attachments": [
+                {
+                  "pretext": "See the details below for a summary of which job(s) failed.",
+                  "color": "#aa0000",
+                  "fields": [
+                    {
+                      "title": "Build/Publish Image",
+                      "short": true,
+                      "value": "${{ needs.build.result }}"
+                    },
+                    {
+                      "title": "Build/Publish Manifests",
+                      "short": true,
+                      "value": "${{ needs.publish_manifests.result }}"
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "Go to workflow run",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.slack-token }}


### PR DESCRIPTION
This PR enables the demo image build workflows to send notifications to Slack.