### PR TITLE
chore(stacks): Bump OPA to 1.4.2

### DIFF
--- a/stacks/data-lakehouse-iceberg-trino-spark/trino.yaml
+++ b/stacks/data-lakehouse-iceberg-trino-spark/trino.yaml
@@ -114,7 +114,7 @@ metadata:
   name: opa
 spec:
   image:
-    productVersion: 1.0.1
+    productVersion: 1.4.2
   servers:
     roleGroups:
       default: {}

--- a/stacks/dual-hive-hdfs-s3/trino.yaml
+++ b/stacks/dual-hive-hdfs-s3/trino.yaml
@@ -86,7 +86,7 @@ metadata:
   name: opa
 spec:
   image:
-    productVersion: 1.0.1
+    productVersion: 1.4.2
   servers:
     roleGroups:
       default:

--- a/stacks/end-to-end-security/opa.yaml
+++ b/stacks/end-to-end-security/opa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: opa
 spec:
   image:
-    productVersion: 1.0.1
+    productVersion: 1.4.2
   clusterConfig:
     userInfo:
       backend:

--- a/stacks/keycloak-opa-poc/opa.yaml
+++ b/stacks/keycloak-opa-poc/opa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: opa
 spec:
   image:
-    productVersion: 1.0.1
+    productVersion: 1.4.2
   servers:
     roleGroups:
       default: {}

--- a/stacks/trino-iceberg/trino.yaml
+++ b/stacks/trino-iceberg/trino.yaml
@@ -99,7 +99,7 @@ metadata:
   name: opa
 spec:
   image:
-    productVersion: 1.0.1
+    productVersion: 1.4.2
   servers:
     roleGroups:
       default:

--- a/stacks/trino-superset-s3/trino.yaml
+++ b/stacks/trino-superset-s3/trino.yaml
@@ -71,7 +71,7 @@ metadata:
   name: opa
 spec:
   image:
-    productVersion: 1.0.1
+    productVersion: 1.4.2
   servers:
     roleGroups:
       default: {}


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1084.

- Bump OPA to `1.4.2` in stacks