### PR TITLE
fix: restore some manifests of signal processing demo

### DIFF
--- a/stacks/signal-processing/serviceaccount.yaml
+++ b/stacks/signal-processing/serviceaccount.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spark
+subjects:
+  - kind: ServiceAccount
+    name: spark
+roleRef:
+  kind: Role
+  name: spark-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spark-role
+rules:
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: [services]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: [configmaps]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: [persistentvolumeclaims]
+    verbs: ["*"]

--- a/stacks/signal-processing/spark_driver_service.yaml
+++ b/stacks/signal-processing/spark_driver_service.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: driver-service
+spec:
+  selector:
+    app: jupyterhub
+    component: singleuser-server
+    hub.jupyter.org/username: admin
+  ports:
+    - name: driver
+      protocol: TCP
+      port: 2222
+      targetPort: 2222
+    - name: blockmanager
+      protocol: TCP
+      port: 7777
+      targetPort: 7777
+    - name: spark-driver-ui-port
+      port: 4040
+      protocol: TCP
+      targetPort: 4040
+  type: ClusterIP

--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -631,8 +631,8 @@ stacks:
       - helmChart: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/_templates/postgresql-timescaledb.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/nifi-kafka-druid-superset-s3/zookeeper.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/signal-processing/nifi.yaml
-      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-pyspark-hdfs/serviceaccount.yaml
-      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-pyspark-hdfs/spark_driver_service.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/signal-processing/serviceaccount.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/signal-processing/spark_driver_service.yaml
       - helmChart: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/signal-processing/jupyterhub.yaml
     parameters:
       - name: nifiAdminPassword


### PR DESCRIPTION
These files were deleted as part of https://github.com/stackabletech/demos/pull/209 but they are still used in the signal processing demo.

Restored manifests and added them to the signal stack.

Tested the demo locally.