### PR TITLE
chore: Update testing issue templates to include 25.7.0 improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/pre-release-from-scratch-testing.md
+++ b/.github/ISSUE_TEMPLATE/pre-release-from-scratch-testing.md
@@ -25,10 +25,6 @@ the products.
 > ```md
 > ## :green_circle: airflow-scheduled-job
 >
->
-> - :hourglass: current stable (25.3.0)
-> - :hourglass: upgrade to nightly (pending external dep bumps)
->
 > Notes can be left here, for example:
 > The CRD had been updated and I needed to change the following in the manifest:
 > ...

--- a/.github/ISSUE_TEMPLATE/pre-release-upgrade-testing.md
+++ b/.github/ISSUE_TEMPLATE/pre-release-upgrade-testing.md
@@ -26,7 +26,7 @@ and products do not negatively impact the products.
 > ## :green_circle: airflow-scheduled-job
 >
 >
-> - :hourglass: current stable (25.3.0)
+> - :hourglass: current stable (OO.M.X)
 > - :hourglass: upgrade to nightly (pending external dep bumps)
 >
 > Notes can be left here, for example:

--- a/.github/ISSUE_TEMPLATE/release-from-scratch-testing.md
+++ b/.github/ISSUE_TEMPLATE/release-from-scratch-testing.md
@@ -24,10 +24,6 @@ This is testing that the new release demos work as documented from scratch.
 > ```md
 > ## :green_circle: airflow-scheduled-job
 >
->
-> - :hourglass: current stable (25.3.0)
-> - :hourglass: upgrade to nightly (pending external dep bumps)
->
 > Notes can be left here, for example:
 > The CRD had been updated and I needed to change the following in the manifest:
 > ...


### PR DESCRIPTION
This adds a few improvements:

- Update the recommended comment to report testing progress and results.
- Add a list of stacks which need to be tested on their own.