### PR TITLE
docs(juypterhub-keycloak: Improve section about web interface access

### DIFF
--- a/docs/modules/demos/pages/jupyterhub-keycloak.adoc
+++ b/docs/modules/demos/pages/jupyterhub-keycloak.adoc
@@ -146,9 +146,11 @@ proxy-648bf7f45b-62vqg       1/1     Running     0          56m
 
 ----
 
-The `proxy` Pod has an associated `proxy-public` service with a statically-defined port (31095), exposed with type NodePort. The `keycloak` Pod has a Service called `keycloak` with a fixed port (31093) of type NodePort as well.
-In order to reach the JupyterHub web interface, navigate to this service.
+The `proxy` Pod has an associated `proxy-public` service with a statically-defined port (31095), exposed with type NodePort.
+The `keycloak` Pod has a Service called `keycloak` with a fixed port (31093) of type NodePort as well.
 The node port IP can be found in the ConfigMap `keycloak-address` (written by the Keycloak Deployment as it starts up).
+Both the Keycloak and the JupyterHub web interface can be accessed via this address, on ports 31093 and 31095 respectively.
+
 On Kind this can be any node - not necessarily the one where the proxy Pod is running.
 This is due to the way in which Docker networking is used within the cluster.
 On other clusters it will be necessary to use the exact Node on which the proxy is running.


### PR DESCRIPTION
Part of https://github.com/stackabletech/demos/issues/242, also see https://github.com/stackabletech/demos/issues/242#issuecomment-3073872205

This PR clarifies how to access the Keycloak and Jupyterhub web interfaces. Personally, I did find that section hard to understand. Now it should be clear, that **both** applications can be accessed using the **same** node port IP address, just on different ports.