### PR TITLE
fix: Remove typo in Druid compaction Job JSON

### DIFF
--- a/demos/nifi-kafka-druid-water-level-data/create-druid-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-water-level-data/create-druid-ingestion-job.yaml
@@ -190,6 +190,6 @@ data:
           ],
           "targetRowsPerSegment": 5000000
         },
-        "maxNumSegmentsToMerge": 500,
+        "maxNumSegmentsToMerge": 500
       }
     }


### PR DESCRIPTION
No one ever noticed :sweat_smile: 