### PR TITLE
fix: increase hbase master memory to avoid the hbase shell being killed

### DIFF
--- a/demos/demos-v2.yaml
+++ b/demos/demos-v2.yaml
@@ -28,9 +28,9 @@ demos:
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/demos/hbase-hdfs-load-cycling-data/create-hfile-and-import-to-hbase.yaml
     supportedNamespaces: []
     resourceRequests:
-      cpu: "3"
-      memory: 5638Mi
-      pvc: 16Gi
+      cpu: 1950m
+      memory: 9216Mi
+      pvc: 21Gi
   end-to-end-security:
     description: Demonstrates end-to-end security across multiple products
     stackableStack: end-to-end-security

--- a/docs/modules/demos/pages/hbase-hdfs-load-cycling-data.adoc
+++ b/docs/modules/demos/pages/hbase-hdfs-load-cycling-data.adoc
@@ -22,7 +22,7 @@ WARNING: This demo should not be run alongside other demos.
 To run this demo, your system needs at least:
 
 * 3 {k8s-cpu}[cpu units] (core/hyperthread)
-* 6GiB memory
+* 7GiB memory
 * 16GiB disk storage
 
 == Overview

--- a/docs/modules/demos/pages/hbase-hdfs-load-cycling-data.adoc
+++ b/docs/modules/demos/pages/hbase-hdfs-load-cycling-data.adoc
@@ -21,9 +21,9 @@ WARNING: This demo should not be run alongside other demos.
 
 To run this demo, your system needs at least:
 
-* 3 {k8s-cpu}[cpu units] (core/hyperthread)
-* 7GiB memory
-* 16GiB disk storage
+* 2 {k8s-cpu}[cpu units] (core/hyperthread)
+* 10 GiB memory
+* 22 GiB disk storage
 
 == Overview
 

--- a/stacks/hdfs-hbase/hbase.yaml
+++ b/stacks/hdfs-hbase/hbase.yaml
@@ -12,10 +12,9 @@ spec:
   masters:
     config:
       listenerClass: external-stable
-      config:
-        resources:
-          memory:
-            limit: 2Gi
+      resources:
+        memory:
+          limit: 2Gi
     roleGroups:
       default:
         replicas: 1

--- a/stacks/hdfs-hbase/hbase.yaml
+++ b/stacks/hdfs-hbase/hbase.yaml
@@ -12,6 +12,10 @@ spec:
   masters:
     config:
       listenerClass: external-stable
+      config:
+        resources:
+          memory:
+            limit: 2Gi
     roleGroups:
       default:
         replicas: 1

--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -186,8 +186,8 @@ stacks:
       - plainYaml: https://raw.githubusercontent.com/stackabletech/demos/main/stacks/hdfs-hbase/hbase.yaml
     supportedNamespaces: []
     resourceRequests:
-      cpu: 4200m
-      memory: 10758Mi
+      cpu: 1950m
+      memory: 8192Mi
       pvc: 21Gi
     parameters: []
   nifi-kafka-druid-superset-s3:


### PR DESCRIPTION
The hbase shell doesn't have enough memory to test this demo.

See https://github.com/stackabletech/issues/issues/752