### PR TITLE
fix(docs): Adjust version from nightly to 25.7 in antora.yaml

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -2,4 +2,4 @@
 # Use 'home' here so that the versioning is picked up automatically based
 # on SDP releases
 name: home
-version: "nightly"
+version: "25.7"


### PR DESCRIPTION
Again, the release script should do this, but currently doesn't.