### PR TITLE
Improve the performance of the Trino Rego rules

### DIFF
--- a/stacks/end-to-end-security/trino-regorules.yaml
+++ b/stacks/end-to-end-security/trino-regorules.yaml
@@ -10,8 +10,6 @@ data:
   actual_permissions.rego: |
     package trino
 
-    import data.util
-
     # This file contains functions to determine the actual permissions
     # defined in the Trino policies for the given user and requested
     # resource.
@@ -35,17 +33,8 @@ data:
     #
     #   Example:
     #     package trino_policies
-    #     extra_groups := groups if {
-    #         request := {
-    #             "method": "POST",
-    #             "url": "http://127.0.0.1:9476/user",
-    #             "headers": {"Content-Type": "application/json"},
-    #             "body": {"username": input.context.identity.user},
-    #         }
-    #         response := http.send(request)
-    #         response.status_code == 200
-    #         groups := response.body.groups
-    #     }
+    #     extra_groups := data.stackable.opa.userinfo.v1.userInfoByUsername(input.context.identity.user).groups
+    # scope: document
     default extra_groups := []
 
     extra_groups := data.trino_policies.extra_groups
@@ -57,20 +46,75 @@ data:
       [""],
     )
 
+    original_user_group_authorization_policies := [rule |
+      some rule in policies.authorization
+      match_original_user_group(rule)
+    ]
+
+    original_user_group_impersonation_policies := [rule |
+      some rule in policies.impersonation
+      match_original_user_group(rule)
+    ]
+
+    user_group_catalog_policies := [rule |
+      some rule in policies.catalogs
+      match_user_group(rule)
+    ]
+
+    user_group_catalog_session_property_policies := [rule |
+      some rule in policies.catalog_session_properties
+      match_user_group(rule)
+    ]
+
+    user_group_function_policies := [rule |
+      some rule in policies.functions
+      match_user_group(rule)
+    ]
+
+    user_group_procedure_policies := [rule |
+      some rule in policies.procedures
+      match_user_group(rule)
+    ]
+
+    user_group_query_policies := [rule |
+      some rule in policies.queries
+      match_user_group(rule)
+    ]
+
+    user_group_schema_policies := [rule |
+      some rule in policies.schemas
+      match_user_group(rule)
+    ]
+
+    user_group_system_information_policies := [rule |
+      some rule in policies.system_information
+      match_user_group(rule)
+    ]
+
+    user_group_system_session_property_policies := [rule |
+      some rule in policies.system_session_properties
+      match_user_group(rule)
+    ]
+
+    user_group_table_policies := [rule |
+      some rule in policies.tables
+      match_user_group(rule)
+    ]
+
     default match_any_group(_) := false
 
     match_any_group(group_pattern) if {
       some group in groups
-      util.match_entire(group_pattern, group)
+      match_entire(group_pattern, group)
     }
 
     default match_user_group(_) := false
 
     match_user_group(rule) if {
       user_pattern := object.get(rule, "user", ".*")
-      group_pattern := object.get(rule, "group", ".*")
+      match_entire(user_pattern, identity.user)
 
-      util.match_entire(user_pattern, identity.user)
+      group_pattern := object.get(rule, "group", ".*")
       match_any_group(group_pattern)
     }
 
@@ -78,21 +122,19 @@ data:
 
     match_original_user_group(rule) if {
       user_pattern := object.get(rule, "original_user", ".*")
-      group_pattern := object.get(rule, "original_group", ".*")
+      match_entire(user_pattern, identity.user)
 
-      util.match_entire(user_pattern, identity.user)
+      group_pattern := object.get(rule, "original_group", ".*")
       match_any_group(group_pattern)
     }
 
     first_matching_authorization_rule(grantee_name) := rule if {
       rules := [rule |
-        some rule in policies.authorization
-
-        match_original_user_group(rule)
+        some rule in original_user_group_authorization_policies
 
         new_user_pattern := object.get(rule, "new_user", ".*")
 
-        util.match_entire(new_user_pattern, grantee_name)
+        match_entire(new_user_pattern, grantee_name)
       ]
       rule := object.union(
         {"allow": true},
@@ -106,13 +148,11 @@ data:
 
     first_matching_catalog_rule(catalog_name) := rule if {
       rules := [rule |
-        some rule in policies.catalogs
-
-        match_user_group(rule)
+        some rule in user_group_catalog_policies
 
         catalog_pattern := object.get(rule, "catalog", ".*")
 
-        util.match_entire(catalog_pattern, catalog_name)
+        match_entire(catalog_pattern, catalog_name)
       ]
       rule := rules[0]
     }
@@ -132,15 +172,13 @@ data:
       property_name,
     ) := rule if {
       rules := [rule |
-        some rule in policies.catalog_session_properties
-
-        match_user_group(rule)
+        some rule in user_group_catalog_session_property_policies
 
         catalog_pattern := object.get(rule, "catalog", ".*")
         property_pattern := object.get(rule, "property", ".*")
 
-        util.match_entire(catalog_pattern, catalog_name)
-        util.match_entire(property_pattern, property_name)
+        match_entire(catalog_pattern, catalog_name)
+        match_entire(property_pattern, property_name)
       ]
       rule := rules[0]
     }
@@ -164,13 +202,11 @@ data:
     catalog_visibility(catalog_name) if {
       catalog_access(catalog_name) == {"read-only"}
 
-      some rule in policies.schemas
-
-      match_user_group(rule)
+      some rule in user_group_schema_policies
 
       catalog_pattern := object.get(rule, "catalog", ".*")
 
-      util.match_entire(catalog_pattern, catalog_name)
+      match_entire(catalog_pattern, catalog_name)
 
       rule.owner == true
     }
@@ -180,19 +216,17 @@ data:
 
       rules := array.concat(
         array.concat(
-          policies.tables,
-          policies.functions,
+          user_group_table_policies,
+          user_group_function_policies,
         ),
-        policies.procedures,
+        user_group_procedure_policies,
       )
 
       some rule in rules
 
-      match_user_group(rule)
-
       catalog_pattern := object.get(rule, "catalog", ".*")
 
-      util.match_entire(catalog_pattern, catalog_name)
+      match_entire(catalog_pattern, catalog_name)
 
       count(rule.privileges) != 0
     }
@@ -200,13 +234,11 @@ data:
     catalog_visibility(catalog_name) if {
       catalog_access(catalog_name) == {"read-only"}
 
-      some rule in policies.catalog_session_properties
-
-      match_user_group(rule)
+      some rule in user_group_catalog_session_property_policies
 
       catalog_pattern := object.get(rule, "catalog", ".*")
 
-      util.match_entire(catalog_pattern, catalog_name)
+      match_entire(catalog_pattern, catalog_name)
 
       rule.allow == true
     }
@@ -217,17 +249,15 @@ data:
       function_name,
     ) := rule if {
       rules := [rule |
-        some rule in policies.functions
-
-        match_user_group(rule)
+        some rule in user_group_function_policies
 
         catalog_pattern := object.get(rule, "catalog", ".*")
         schema_pattern := object.get(rule, "schema", ".*")
         function_pattern := object.get(rule, "function", ".*")
 
-        util.match_entire(catalog_pattern, catalog_name)
-        util.match_entire(schema_pattern, schema_name)
-        util.match_entire(function_pattern, function_name)
+        match_entire(catalog_pattern, catalog_name)
+        match_entire(schema_pattern, schema_name)
+        match_entire(function_pattern, function_name)
       ]
       rule := rules[0]
     }
@@ -248,9 +278,7 @@ data:
 
     first_matching_impersonation_rule(user) := rule if {
       rules := [rule |
-        some rule in policies.impersonation
-
-        match_original_user_group(rule)
+        some rule in original_user_group_impersonation_policies
 
         original_user_pattern := object.get(rule, "original_user", ".*")
         unsubstituted_new_user_pattern := object.get(rule, "new_user", ".*")
@@ -271,7 +299,7 @@ data:
           unsubstituted_new_user_pattern,
         )
 
-        util.match_entire(new_user_pattern, user)
+        match_entire(new_user_pattern, user)
       ]
       rule := object.union(
         {"allow": true},
@@ -301,17 +329,15 @@ data:
       function_name,
     ) := rule if {
       rules := [rule |
-        some rule in policies.procedures
-
-        match_user_group(rule)
+        some rule in user_group_procedure_policies
 
         catalog_pattern := object.get(rule, "catalog", ".*")
         schema_pattern := object.get(rule, "schema", ".*")
         procedure_pattern := object.get(rule, "procedure", ".*")
 
-        util.match_entire(catalog_pattern, catalog_name)
-        util.match_entire(schema_pattern, schema_name)
-        util.match_entire(procedure_pattern, function_name)
+        match_entire(catalog_pattern, catalog_name)
+        match_entire(schema_pattern, schema_name)
+        match_entire(procedure_pattern, function_name)
       ]
       rule := rules[0]
     }
@@ -330,14 +356,7 @@ data:
       ).privileges
     }
 
-    first_matching_query_rule := rule if {
-      rules := [rule |
-        some rule in policies.queries
-
-        match_user_group(rule)
-      ]
-      rule := rules[0]
-    }
+    first_matching_query_rule := user_group_query_policies[0]
 
     default query_access := set()
 
@@ -345,13 +364,11 @@ data:
 
     first_matching_query_owned_by_rule(user) := rule if {
       rules := [rule |
-        some rule in policies.queries
-
-        match_user_group(rule)
+        some rule in user_group_query_policies
 
         query_owner_pattern := object.get(rule, "queryOwner", ".*")
 
-        util.match_entire(query_owner_pattern, user)
+        match_entire(query_owner_pattern, user)
       ]
       rule := rules[0]
     }
@@ -371,15 +388,13 @@ data:
 
     first_matching_schema_rule(catalog_name, schema_name) := rule if {
       rules := [rule |
-        some rule in policies.schemas
-
-        match_user_group(rule)
+        some rule in user_group_schema_policies
 
         catalog_pattern := object.get(rule, "catalog", ".*")
         schema_pattern := object.get(rule, "schema", ".*")
 
-        util.match_entire(catalog_pattern, catalog_name)
-        util.match_entire(schema_pattern, schema_name)
+        match_entire(catalog_pattern, catalog_name)
+        match_entire(schema_pattern, schema_name)
       ]
       rule := rules[0]
     }
@@ -404,21 +419,19 @@ data:
 
       rules := array.concat(
         array.concat(
-          policies.tables,
-          policies.functions,
+          user_group_table_policies,
+          user_group_function_policies,
         ),
-        policies.procedures,
+        user_group_procedure_policies,
       )
 
       some rule in rules
 
-      match_user_group(rule)
-
       catalog_pattern := object.get(rule, "catalog", ".*")
-      schema_pattern := object.get(rule, "schema", ".*")
+      match_entire(catalog_pattern, catalog_name)
 
-      util.match_entire(catalog_pattern, catalog_name)
-      util.match_entire(schema_pattern, schema_name)
+      schema_pattern := object.get(rule, "schema", ".*")
+      match_entire(schema_pattern, schema_name)
 
       count(rule.privileges) != 0
     }
@@ -444,17 +457,15 @@ data:
     ) := rule if {
       schema_name != "information_schema"
       rules := [rule |
-        some rule in policies.tables
-
-        match_user_group(rule)
+        some rule in user_group_table_policies
 
         catalog_pattern := object.get(rule, "catalog", ".*")
         schema_pattern := object.get(rule, "schema", ".*")
         table_pattern := object.get(rule, "table", ".*")
 
-        util.match_entire(catalog_pattern, catalog_name)
-        util.match_entire(schema_pattern, schema_name)
-        util.match_entire(table_pattern, table_name)
+        match_entire(catalog_pattern, catalog_name)
+        match_entire(schema_pattern, schema_name)
+        match_entire(table_pattern, table_name)
       ]
       rule := object.union(
         {
@@ -542,14 +553,7 @@ data:
       access := column.allow
     }
 
-    first_matching_system_information_rule := rule if {
-      rules := [rule |
-        some rule in policies.system_information
-
-        match_user_group(rule)
-      ]
-      rule := rules[0]
-    }
+    first_matching_system_information_rule := user_group_system_information_policies[0]
 
     default system_information_access := set()
 
@@ -559,13 +563,11 @@ data:
 
     first_matching_system_session_properties_rule(property_name) := rule if {
       rules := [rule |
-        some rule in policies.system_session_properties
-
-        match_user_group(rule)
+        some rule in user_group_system_session_property_policies
 
         property_name_pattern := object.get(rule, "property", ".*")
 
-        util.match_entire(property_name_pattern, property_name)
+        match_entire(property_name_pattern, property_name)
       ]
       rule := rules[0]
     }
@@ -575,8 +577,6 @@ data:
     system_session_properties_access(property_name) := first_matching_system_session_properties_rule(property_name).allow
   policies.rego: |
     package trino
-
-    import data.util
 
     # The final policies are a combination of policies offered by Stackable,
     # policies provided externally, and default policies.
@@ -761,12 +761,8 @@ data:
     # for the file-based access control
     # (https://trino.io/docs/current/security/file-system-access-control.html).
 
-    action := input.action
-
-    operation := action.operation
-
-    requested_permissions := permissions if {
-      operation == "AccessCatalog"
+    requested_permissions(action) := permissions if {
+      action.operation == "AccessCatalog"
       permissions := {{
         "resource": "catalog",
         "catalogName": action.resource.catalog.name,
@@ -774,8 +770,8 @@ data:
       }}
     }
 
-    requested_permissions := permissions if {
-      operation in {
+    requested_permissions(action) := permissions if {
+      action.operation in {
         "CreateSchema",
         "DropSchema",
         "ShowCreateSchema",
@@ -795,8 +791,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation in {
+    requested_permissions(action) := permissions if {
+      action.operation in {
         "AddColumn",
         "AlterColumn",
         "CreateMaterializedView",
@@ -831,8 +827,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation in {
+    requested_permissions(action) := permissions if {
+      action.operation in {
         "RefreshMaterializedView",
         "UpdateTableColumns",
       }
@@ -852,8 +848,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation in {
+    requested_permissions(action) := permissions if {
+      action.operation in {
         "DeleteFromTable",
         "TruncateTable",
       }
@@ -873,23 +869,23 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation == "ExecuteQuery"
+    requested_permissions(action) := permissions if {
+      action.operation == "ExecuteQuery"
       permissions := {{
         "resource": "query",
         "allow": {"execute"},
       }}
     }
 
-    requested_permissions := permissions if {
-      operation == "ExecuteTableProcedure"
+    requested_permissions(action) := permissions if {
+      action.operation == "ExecuteTableProcedure"
 
       # Executing table procedures is always allowed
       permissions := set()
     }
 
-    requested_permissions := permissions if {
-      operation == "FilterColumns"
+    requested_permissions(action) := permissions if {
+      action.operation == "FilterColumns"
       permissions := {
         {
           "resource": "table",
@@ -916,8 +912,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation == "KillQueryOwnedBy"
+    requested_permissions(action) := permissions if {
+      action.operation == "KillQueryOwnedBy"
       permissions := {{
         "resource": "query_owned_by",
         "user": action.resource.user.user,
@@ -926,8 +922,8 @@ data:
       }}
     }
 
-    requested_permissions := permissions if {
-      operation in {
+    requested_permissions(action) := permissions if {
+      action.operation in {
         "FilterViewQueryOwnedBy",
         "ViewQueryOwnedBy",
       }
@@ -939,8 +935,8 @@ data:
       }}
     }
 
-    requested_permissions := permissions if {
-      operation == "FilterTables"
+    requested_permissions(action) := permissions if {
+      action.operation == "FilterTables"
       permissions := {
         {
           "resource": "catalog",
@@ -964,8 +960,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation in {
+    requested_permissions(action) := permissions if {
+      action.operation in {
         "CreateFunction",
         "DropFunction",
       }
@@ -985,8 +981,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation in {
+    requested_permissions(action) := permissions if {
+      action.operation in {
         "ExecuteFunction",
         "FilterFunctions",
       }
@@ -1006,8 +1002,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation == "ExecuteProcedure"
+    requested_permissions(action) := permissions if {
+      action.operation == "ExecuteProcedure"
       permissions := {
         {
           "resource": "catalog",
@@ -1024,8 +1020,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation == "CreateViewWithExecuteFunction"
+    requested_permissions(action) := permissions if {
+      action.operation == "CreateViewWithExecuteFunction"
       permissions := {
         {
           "resource": "catalog",
@@ -1042,8 +1038,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation == "ImpersonateUser"
+    requested_permissions(action) := permissions if {
+      action.operation == "ImpersonateUser"
       permissions := {{
         "resource": "impersonation",
         "user": action.resource.user.user,
@@ -1051,8 +1047,8 @@ data:
       }}
     }
 
-    requested_permissions := permissions if {
-      operation == "InsertIntoTable"
+    requested_permissions(action) := permissions if {
+      action.operation == "InsertIntoTable"
       permissions := {
         {
           "resource": "catalog",
@@ -1069,16 +1065,16 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation == "ReadSystemInformation"
+    requested_permissions(action) := permissions if {
+      action.operation == "ReadSystemInformation"
       permissions := {{
         "resource": "system_information",
         "allow": {"read"},
       }}
     }
 
-    requested_permissions := permissions if {
-      operation == "RenameSchema"
+    requested_permissions(action) := permissions if {
+      action.operation == "RenameSchema"
       permissions := {
         {
           "resource": "catalog",
@@ -1105,8 +1101,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation in {
+    requested_permissions(action) := permissions if {
+      action.operation in {
         "RenameMaterializedView",
         "RenameTable",
         "RenameView",
@@ -1139,8 +1135,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation == "SelectFromColumns"
+    requested_permissions(action) := permissions if {
+      action.operation == "SelectFromColumns"
       column_permissions := {
       {
         "resource": "column",
@@ -1168,8 +1164,8 @@ data:
       } | column_permissions
     }
 
-    requested_permissions := permissions if {
-      operation == "SetSchemaAuthorization"
+    requested_permissions(action) := permissions if {
+      action.operation == "SetSchemaAuthorization"
       permissions := {
         {
           "resource": "catalog",
@@ -1191,8 +1187,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation in {
+    requested_permissions(action) := permissions if {
+      action.operation in {
         "SetTableAuthorization",
         "SetViewAuthorization",
       }
@@ -1218,8 +1214,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation == "ShowColumns"
+    requested_permissions(action) := permissions if {
+      action.operation == "ShowColumns"
       permissions := {
         {
           "resource": "catalog",
@@ -1243,8 +1239,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation in {
+    requested_permissions(action) := permissions if {
+      action.operation in {
         "FilterCatalogs",
         "ShowSchemas",
       }
@@ -1261,8 +1257,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation in {
+    requested_permissions(action) := permissions if {
+      action.operation in {
         "FilterSchemas",
         "ShowFunctions",
         "ShowTables",
@@ -1281,8 +1277,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation == "SetCatalogSessionProperty"
+    requested_permissions(action) := permissions if {
+      action.operation == "SetCatalogSessionProperty"
       permissions := {
         {
           "resource": "catalog",
@@ -1298,8 +1294,8 @@ data:
       }
     }
 
-    requested_permissions := permissions if {
-      operation == "SetSystemSessionProperty"
+    requested_permissions(action) := permissions if {
+      action.operation == "SetSystemSessionProperty"
       permissions := {{
         "resource": "system_session_properties",
         "propertyName": action.resource.systemSessionProperty.name,
@@ -1307,91 +1303,91 @@ data:
       }}
     }
 
-    requested_permissions := permissions if {
-      operation == "WriteSystemInformation"
+    requested_permissions(action) := permissions if {
+      action.operation == "WriteSystemInformation"
       permissions := {{
         "resource": "system_information",
         "allow": {"write"},
       }}
     }
 
-    requested_authorization_permissions contains permission if {
-      some permission in requested_permissions
+    requested_authorization_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "authorization"
-    }
+    ]
 
-    requested_catalog_permissions contains permission if {
-      some permission in requested_permissions
+    requested_catalog_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "catalog"
-    }
+    ]
 
-    requested_catalog_session_properties_permissions contains permission if {
-      some permission in requested_permissions
+    requested_catalog_session_properties_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "catalog_session_properties"
-    }
+    ]
 
-    requested_catalog_visibility_permissions contains permission if {
-      some permission in requested_permissions
+    requested_catalog_visibility_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "catalog_visibility"
-    }
+    ]
 
-    requested_column_permissions contains permission if {
-      some permission in requested_permissions
+    requested_column_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "column"
-    }
+    ]
 
-    requested_function_permissions contains permission if {
-      some permission in requested_permissions
+    requested_function_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "function"
-    }
+    ]
 
-    requested_impersonation_permissions contains permission if {
-      some permission in requested_permissions
+    requested_impersonation_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "impersonation"
-    }
+    ]
 
-    requested_procedure_permissions contains permission if {
-      some permission in requested_permissions
+    requested_procedure_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "procedure"
-    }
+    ]
 
-    requested_query_permissions contains permission if {
-      some permission in requested_permissions
+    requested_query_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "query"
-    }
+    ]
 
-    requested_query_owned_by_permissions contains permission if {
-      some permission in requested_permissions
+    requested_query_owned_by_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "query_owned_by"
-    }
+    ]
 
-    requested_schema_permissions contains permission if {
-      some permission in requested_permissions
+    requested_schema_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "schema"
-    }
+    ]
 
-    requested_schema_visibility_permissions contains permission if {
-      some permission in requested_permissions
+    requested_schema_visibility_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "schema_visibility"
-    }
+    ]
 
-    requested_table_permissions contains permission if {
-      some permission in requested_permissions
+    requested_table_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "table"
-    }
+    ]
 
-    requested_system_information_permissions contains permission if {
-      some permission in requested_permissions
+    requested_system_information_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "system_information"
-    }
+    ]
 
-    requested_system_session_properties_permissions contains permission if {
-      some permission in requested_permissions
+    requested_system_session_properties_permissions(action) := [permission |
+      some permission in requested_permissions(action)
       permission.resource == "system_session_properties"
-    }
+    ]
 
-    requested_column_mask := request if {
-      operation == "GetColumnMask"
+    requested_column_mask(action) := request if {
+      action.operation == "GetColumnMask"
       request := {
         "catalogName": action.resource.column.catalogName,
         "schemaName": action.resource.column.schemaName,
@@ -1400,8 +1396,8 @@ data:
       }
     }
 
-    requested_row_filters := request if {
-      operation == "GetRowFilters"
+    requested_row_filters(action) := request if {
+      action.operation == "GetRowFilters"
       request := {
         "catalogName": action.resource.table.catalogName,
         "schemaName": action.resource.table.schemaName,
@@ -1473,34 +1469,36 @@ data:
     # entrypoint: true
     default allow := false
 
-    allow if {
+    allow := allowWith(input.action)
+
+    allowWith(action) if {
       # Fail if the requested permissions for the given operation are not
       # implemented yet
       #
       # The following operations are intentionally not supported:
       # - CreateCatalog
       # - DropCatalog
-      requested_permissions
+      requested_permissions(action)
 
-      every requested_permission in requested_authorization_permissions {
+      every requested_permission in requested_authorization_permissions(action) {
         permission := authorization_permission(requested_permission.granteeName)
         requested_permission.allow == permission
       }
-      every requested_permission in requested_catalog_permissions {
+      every requested_permission in requested_catalog_permissions(action) {
         access := catalog_access(requested_permission.catalogName)
         requested_permission.allow in access
       }
-      every requested_permission in requested_catalog_session_properties_permissions {
+      every requested_permission in requested_catalog_session_properties_permissions(action) {
         access := catalog_session_properties_access(
           requested_permission.catalogName,
           requested_permission.propertyName,
         )
         requested_permission.allow == access
       }
-      every requested_permission in requested_catalog_visibility_permissions {
+      every requested_permission in requested_catalog_visibility_permissions(action) {
         catalog_visibility(requested_permission.catalogName)
       }
-      every requested_permission in requested_column_permissions {
+      every requested_permission in requested_column_permissions(action) {
         access := column_access(
           requested_permission.catalogName,
           requested_permission.schemaName,
@@ -1509,7 +1507,7 @@ data:
         )
         requested_permission.allow == access
       }
-      every requested_permission in requested_function_permissions {
+      every requested_permission in requested_function_permissions(action) {
         privileges := function_privileges(
           requested_permission.catalogName,
           requested_permission.schemaName,
@@ -1517,11 +1515,11 @@ data:
         )
         object.subset(privileges, requested_permission.privileges)
       }
-      every requested_permission in requested_impersonation_permissions {
+      every requested_permission in requested_impersonation_permissions(action) {
         access := impersonation_access(requested_permission.user)
         requested_permission.allow == access
       }
-      every requested_permission in requested_procedure_permissions {
+      every requested_permission in requested_procedure_permissions(action) {
         privileges := procedure_privileges(
           requested_permission.catalogName,
           requested_permission.schemaName,
@@ -1529,28 +1527,28 @@ data:
         )
         object.subset(privileges, requested_permission.privileges)
       }
-      every requested_permission in requested_query_permissions {
+      every requested_permission in requested_query_permissions(action) {
         object.subset(query_access, requested_permission.allow)
       }
-      every requested_permission in requested_query_owned_by_permissions {
+      every requested_permission in requested_query_owned_by_permissions(action) {
         object.subset(
           query_owned_by_access(requested_permission.user),
           requested_permission.allow,
         )
       }
-      every requested_permission in requested_schema_permissions {
+      every requested_permission in requested_schema_permissions(action) {
         schema_owner(
           requested_permission.catalogName,
           requested_permission.schemaName,
         ) == requested_permission.owner
       }
-      every requested_permission in requested_schema_visibility_permissions {
+      every requested_permission in requested_schema_visibility_permissions(action) {
         schema_visibility(
           requested_permission.catalogName,
           requested_permission.schemaName,
         )
       }
-      every requested_permission in requested_table_permissions {
+      every requested_permission in requested_table_permissions(action) {
         privileges := table_privileges(
           requested_permission.catalogName,
           requested_permission.schemaName,
@@ -1569,13 +1567,13 @@ data:
         object.subset(privileges, all_of_requested)
         privileges & any_of_requested != set()
       }
-      every requested_permission in requested_system_information_permissions {
+      every requested_permission in requested_system_information_permissions(action) {
         object.subset(
           system_information_access,
           requested_permission.allow,
         )
       }
-      every requested_permission in requested_system_session_properties_permissions {
+      every requested_permission in requested_system_session_properties_permissions(action) {
         access := system_session_properties_access(requested_permission.propertyName)
         requested_permission.allow == access
       }
@@ -1620,8 +1618,9 @@ data:
 
       some index, resource in input.action.filterResources
 
-      # regal ignore:with-outside-test-context
-      allow with input.action.resource as resource
+      action := object.union(object.remove(input.action, {"filterResources"}), {"resource": resource})
+
+      allowWith(action)
     }
 
     batch contains index if {
@@ -1630,13 +1629,14 @@ data:
       table := input.action.filterResources[0].table
       some index, column_name in table.columns
 
-      # regal ignore:with-outside-test-context
-      allow with input.action.resource as {"table": {
+      action := object.union(object.remove(input.action, {"filterResources"}), {"resource": {"table": {
         "catalogName": table.catalogName,
         "schemaName": table.schemaName,
         "tableName": table.tableName,
         "columnName": column_name,
-      }}
+      }}})
+
+      allowWith(action)
     }
 
     # METADATA
@@ -1675,11 +1675,13 @@ data:
     #   is an SQL expression, e.g. "'XXX-XX-' + substring(credit_card, -4)".
     # entrypoint: true
     columnMask := column_mask if {
+      request := requested_column_mask(input.action)
+
       column := column_constraints(
-        requested_column_mask.catalogName,
-        requested_column_mask.schemaName,
-        requested_column_mask.tableName,
-        requested_column_mask.columnName,
+        request.catalogName,
+        request.schemaName,
+        request.tableName,
+        request.columnName,
       )
 
       is_string(column.mask)
@@ -1692,11 +1694,13 @@ data:
     }
 
     columnMask := column_mask if {
+      request := requested_column_mask(input.action)
+
       column := column_constraints(
-        requested_column_mask.catalogName,
-        requested_column_mask.schemaName,
-        requested_column_mask.tableName,
-        requested_column_mask.columnName,
+        request.catalogName,
+        request.schemaName,
+        request.tableName,
+        request.columnName,
       )
 
       is_string(column.mask)
@@ -1740,10 +1744,12 @@ data:
     #   an SQL condition, e.g. "user = current_user".
     # entrypoint: true
     rowFilters contains row_filter if {
+      request := requested_row_filters(input.action)
+
       rule := first_matching_table_rule(
-        requested_row_filters.catalogName,
-        requested_row_filters.schemaName,
-        requested_row_filters.tableName,
+        request.catalogName,
+        request.schemaName,
+        request.tableName,
       )
 
       is_string(rule.filter)
@@ -1756,10 +1762,12 @@ data:
     }
 
     rowFilters contains row_filter if {
+      request := requested_row_filters(input.action)
+
       rule := first_matching_table_rule(
-        requested_row_filters.catalogName,
-        requested_row_filters.schemaName,
-        requested_row_filters.tableName,
+        request.catalogName,
+        request.schemaName,
+        request.tableName,
       )
 
       is_string(rule.filter)
@@ -1768,9 +1776,7 @@ data:
       row_filter := {"expression": rule.filter}
     }
   util.rego: |
-    # METADATA
-    # description: Utility package which extends the built-in functions
-    package util
+    package trino
 
     # METADATA
     # description: |
@@ -1781,7 +1787,12 @@ data:
     #
     #   Returns:
     #     result (boolean)
+    # scope: document
+    match_entire(`.*`, value)
+
     match_entire(pattern, value) if {
+      pattern != `.*`
+
       # Add the anchors ^ and $
       pattern_with_anchors := concat("", ["^", pattern, "$"])
 


### PR DESCRIPTION
Improve the performance of the Trino Rego rules

see stackabletech/trino-operator#782

The new Trino rules were copied from the integration test to the end-to-end-security stack.

The [end-to-end-security demo](https://docs.stackable.tech/home/stable/demos/end-to-end-security/) was successfully tested with the new rules.

## Release notes

The performance of the Trino rules in the end-to-end-security stack was improved. Batch queries are now significantly faster.