### PR TITLE
chore: update demos to use bitnamilegacy

### DIFF
--- a/demos/data-lakehouse-iceberg-trino-spark/load-test-data.yaml
+++ b/demos/data-lakehouse-iceberg-trino-spark/load-test-data.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: load-test-data
-          image: "bitnami/minio:2024-debian-12"
+          image: "bitnamilegacy/minio:2024-debian-12"
           # Please try to order the load jobs from small to large datasets
           command:
             - bash

--- a/demos/jupyterhub-keycloak/load-gas-data.yaml
+++ b/demos/jupyterhub-keycloak/load-gas-data.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: load-gas-data
-          image: "bitnami/minio:2022-debian-10"
+          image: "bitnamilegacy/minio:2022-debian-10"
           command: ["bash", "-c", "cd /tmp; curl -O https://repo.stackable.tech/repository/misc/datasets/gas-sensor-data/20160930_203718.csv && mc --insecure alias set minio http://minio:9000/ $(cat /minio-s3-credentials/accessKey) $(cat /minio-s3-credentials/secretKey) && mc cp 20160930_203718.csv minio/demo/gas-sensor/raw/;"]
           volumeMounts:
             - name: minio-s3-credentials

--- a/demos/spark-k8s-anomaly-detection-taxi-data/load-test-data.yaml
+++ b/demos/spark-k8s-anomaly-detection-taxi-data/load-test-data.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: load-ny-taxi-data
-          image: "bitnami/minio:2022-debian-10"
+          image: "bitnamilegacy/minio:2022-debian-10"
           # yamllint disable-line rule:line-length
           command:
             - "bash"

--- a/demos/trino-taxi-data/load-test-data.yaml
+++ b/demos/trino-taxi-data/load-test-data.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: load-ny-taxi-data
-          image: "bitnami/minio:2024-debian-12"
+          image: "bitnamilegacy/minio:2024-debian-12"
           # yamllint disable-line rule:line-length
           command:
             - bash

--- a/stacks/_templates/postgresql-airflow.yaml
+++ b/stacks/_templates/postgresql-airflow.yaml
@@ -12,3 +12,14 @@ options:
     username: airflow
     password: airflow
     database: airflow
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter

--- a/stacks/_templates/postgresql-druid.yaml
+++ b/stacks/_templates/postgresql-druid.yaml
@@ -12,3 +12,14 @@ options:
     username: druid
     password: druid
     database: druid
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter

--- a/stacks/_templates/postgresql-hive-iceberg.yaml
+++ b/stacks/_templates/postgresql-hive-iceberg.yaml
@@ -12,3 +12,14 @@ options:
     username: hive
     password: hive
     database: hive
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter

--- a/stacks/_templates/postgresql-hive.yaml
+++ b/stacks/_templates/postgresql-hive.yaml
@@ -12,3 +12,14 @@ options:
     username: hive
     password: hive
     database: hive
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter

--- a/stacks/_templates/postgresql-hivehdfs.yaml
+++ b/stacks/_templates/postgresql-hivehdfs.yaml
@@ -12,3 +12,14 @@ options:
     username: hive
     password: hive
     database: hivehdfs
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter

--- a/stacks/_templates/postgresql-hives3.yaml
+++ b/stacks/_templates/postgresql-hives3.yaml
@@ -12,3 +12,14 @@ options:
     username: hive
     password: hive
     database: hives3
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter

--- a/stacks/_templates/postgresql-superset.yaml
+++ b/stacks/_templates/postgresql-superset.yaml
@@ -12,3 +12,14 @@ options:
     username: superset
     password: superset
     database: superset
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter

--- a/stacks/_templates/redis-airflow.yaml
+++ b/stacks/_templates/redis-airflow.yaml
@@ -12,3 +12,23 @@ options:
     password: airflow
   replica:
     replicaCount: 1
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/redis
+  sentinel:
+    image:
+      repository: bitnamilegacy/redis-sentinel
+  metrics:
+    image:
+      repository: bitnamilegacy/redis-exporter
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  kubectl:
+    image:
+      repository: bitnamilegacy/kubectl
+  sysctl:
+    image:
+      repository: bitnamilegacy/os-shell

--- a/stacks/authentication/openldap-tls.yaml
+++ b/stacks/authentication/openldap-tls.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: openldap
-          image: docker.io/bitnami/openldap:2.6
+          image: docker.io/bitnamilegacy/openldap:2.6
           env:
             # The Admin credentials. These are used to bind later.
             - name: LDAP_ADMIN_USERNAME

--- a/stacks/end-to-end-security/setup-postgresql.yaml
+++ b/stacks/end-to-end-security/setup-postgresql.yaml
@@ -26,7 +26,7 @@ spec:
               mountPath: /dump/
       containers:
         - name: restore-postgres
-          image: docker.io/bitnami/postgresql:16.1.0-debian-11-r11 # Same image as the bitnami postgres helm-chart is using
+          image: docker.io/bitnamilegacy/postgresql:16.1.0-debian-11-r11 # Same image as the bitnami postgres helm-chart is using
           command:
             - bash
             - -c


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/749 and follow up to https://github.com/stackabletech/demos/pull/290
This PR updates the demos of the 25.7 release to use bitnamilegacy.