### PR TITLE
Set max_renewable_life = 7d in KDC realm config

### DIFF
--- a/stacks/end-to-end-security/krb5.yaml
+++ b/stacks/end-to-end-security/krb5.yaml
@@ -122,6 +122,7 @@ data:
     KNAB.COM = {
      acl_file = /stackable/config/kadm5.acl
      disable_encrypted_timestamp = false
+     max_renewable_life = 7d
     }
     [domain_realm]
     .cluster.local = KNAB.COM


### PR DESCRIPTION
Setting max_renewable_life = 7d means by default tickets will be renewable for 7 days. This is useful for applications that expect tickets to be renewable as part of their ticket lifecycle management.