### PR TITLE
chore(spark): bump version to 4.0.1

### DIFF
--- a/demos/data-lakehouse-iceberg-trino-spark/create-spark-ingestion-job.yaml
+++ b/demos/data-lakehouse-iceberg-trino-spark/create-spark-ingestion-job.yaml
@@ -144,13 +144,13 @@ data:
         stackable.tech/vendor: Stackable
     spec:
       sparkImage:
-        productVersion: 3.5.7
+        productVersion: 4.0.1
       mode: cluster
       mainApplicationFile: local:///stackable/spark/jobs/spark-ingest-into-lakehouse.py
       deps:
         packages:
-          - org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.8.1
-          - org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.7
+          - org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.0
+          - org.apache.spark:spark-sql-kafka-0-10_2.13:4.0.1
       s3connection:
         reference: minio
       sparkConf:

--- a/demos/data-lakehouse-iceberg-trino-spark/create-spark-ingestion-job.yaml
+++ b/demos/data-lakehouse-iceberg-trino-spark/create-spark-ingestion-job.yaml
@@ -144,13 +144,13 @@ data:
         stackable.tech/vendor: Stackable
     spec:
       sparkImage:
-        productVersion: 3.5.6
+        productVersion: 3.5.7
       mode: cluster
       mainApplicationFile: local:///stackable/spark/jobs/spark-ingest-into-lakehouse.py
       deps:
         packages:
           - org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.8.1
-          - org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.6
+          - org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.7
       s3connection:
         reference: minio
       sparkConf:

--- a/demos/end-to-end-security/create-spark-report.yaml
+++ b/demos/end-to-end-security/create-spark-report.yaml
@@ -55,7 +55,7 @@ data:
       name: spark-report
     spec:
       sparkImage:
-        productVersion: 3.5.6
+        productVersion: 3.5.7
       mode: cluster
       mainApplicationFile: local:///stackable/spark/jobs/spark-report.py
       deps:

--- a/demos/end-to-end-security/create-spark-report.yaml
+++ b/demos/end-to-end-security/create-spark-report.yaml
@@ -55,12 +55,12 @@ data:
       name: spark-report
     spec:
       sparkImage:
-        productVersion: 3.5.7
+        productVersion: 4.0.1
       mode: cluster
       mainApplicationFile: local:///stackable/spark/jobs/spark-report.py
       deps:
         packages:
-          - org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.8.1
+          - org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.0
       sparkConf:
         spark.driver.extraClassPath: /stackable/config/hdfs
         spark.executor.extraClassPath: /stackable/config/hdfs

--- a/demos/spark-k8s-anomaly-detection-taxi-data/create-spark-anomaly-detection-job.yaml
+++ b/demos/spark-k8s-anomaly-detection-taxi-data/create-spark-anomaly-detection-job.yaml
@@ -51,12 +51,12 @@ data:
       name: spark-ad
     spec:
       sparkImage:
-        productVersion: 3.5.7
+        productVersion: 4.0.1
       mode: cluster
       mainApplicationFile: local:///spark-scripts/spark-ad.py
       deps:
         packages:
-          - org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.8.1
+          - org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.1
         requirements:
           - scikit-learn==1.4.0
       s3connection:

--- a/demos/spark-k8s-anomaly-detection-taxi-data/create-spark-anomaly-detection-job.yaml
+++ b/demos/spark-k8s-anomaly-detection-taxi-data/create-spark-anomaly-detection-job.yaml
@@ -10,22 +10,22 @@ spec:
         - name: wait-for-testdata
           image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           command:
-          - bash
-          - -euo
-          - pipefail
-          - -c
-          - |
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
               echo 'Waiting for job load-ny-taxi-data to finish'
               kubectl wait --for=condition=complete --timeout=30m job/load-ny-taxi-data
       containers:
         - name: create-spark-anomaly-detection-job
           image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           command:
-          - bash
-          - -euo
-          - pipefail
-          - -c
-          - |
+            - bash
+            - -euo
+            - pipefail
+            - -c
+            - |
               echo 'Submitting Spark job'
               kubectl apply -f /tmp/manifest/spark-ad-job.yaml
           volumeMounts:
@@ -51,7 +51,7 @@ data:
       name: spark-ad
     spec:
       sparkImage:
-        productVersion: 3.5.6
+        productVersion: 3.5.7
       mode: cluster
       mainApplicationFile: local:///spark-scripts/spark-ad.py
       deps:

--- a/stacks/airflow/airflow.yaml
+++ b/stacks/airflow/airflow.yaml
@@ -303,7 +303,7 @@ data:
     spec:
       version: "1.0"
       sparkImage:
-        productVersion: 3.5.6
+        productVersion: 3.5.7
       mode: cluster
       mainApplicationFile: local:///stackable/spark/examples/src/main/python/pi.py
       job:
@@ -331,6 +331,7 @@ data:
             memory:
               limit: 1024Mi
         replicas: 3
+
 # {% endraw %}
 ---
 apiVersion: v1

--- a/stacks/airflow/airflow.yaml
+++ b/stacks/airflow/airflow.yaml
@@ -303,7 +303,7 @@ data:
     spec:
       version: "1.0"
       sparkImage:
-        productVersion: 3.5.7
+        productVersion: 4.0.1
       mode: cluster
       mainApplicationFile: local:///stackable/spark/examples/src/main/python/pi.py
       job:
@@ -331,6 +331,7 @@ data:
             memory:
               limit: 1024Mi
         replicas: 3
+
 
 # {% endraw %}
 ---

--- a/stacks/jupyterhub-pyspark-hdfs/jupyterlab.yaml
+++ b/stacks/jupyterhub-pyspark-hdfs/jupyterlab.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: jupyterlab
-          image: oci.stackable.tech/stackable/spark-connect-client:3.5.7-stackable0.0.0-dev
+          image: oci.stackable.tech/stackable/spark-connect-client:4.0.1-stackable0.0.0-dev
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -39,7 +39,7 @@ spec:
               name: notebook
       initContainers:
         - name: download-notebook
-          image: oci.stackable.tech/stackable/spark-connect-client:3.5.7-stackable0.0.0-dev
+          image: oci.stackable.tech/stackable/spark-connect-client:4.0.1-stackable0.0.0-dev
           command:
             - bash
           args:

--- a/stacks/jupyterhub-pyspark-hdfs/jupyterlab.yaml
+++ b/stacks/jupyterhub-pyspark-hdfs/jupyterlab.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: jupyterlab
-          image: oci.stackable.tech/stackable/spark-connect-client:3.5.6-stackable0.0.0-dev
+          image: oci.stackable.tech/stackable/spark-connect-client:3.5.7-stackable0.0.0-dev
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -39,8 +39,13 @@ spec:
               name: notebook
       initContainers:
         - name: download-notebook
-          image: oci.stackable.tech/stackable/spark-connect-client:3.5.6-stackable0.0.0-dev
-          command: ['sh', '-c', 'curl https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-pyspark-hdfs/notebook.ipynb -o /notebook/notebook.ipynb']
+          image: oci.stackable.tech/stackable/spark-connect-client:3.5.7-stackable0.0.0-dev
+          command:
+            [
+              "sh",
+              "-c",
+              "curl https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-pyspark-hdfs/notebook.ipynb -o /notebook/notebook.ipynb",
+            ]
           volumeMounts:
             - mountPath: /notebook
               name: notebook

--- a/stacks/jupyterhub-pyspark-hdfs/jupyterlab.yaml
+++ b/stacks/jupyterhub-pyspark-hdfs/jupyterlab.yaml
@@ -41,11 +41,10 @@ spec:
         - name: download-notebook
           image: oci.stackable.tech/stackable/spark-connect-client:3.5.7-stackable0.0.0-dev
           command:
-            [
-              "sh",
-              "-c",
-              "curl https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-pyspark-hdfs/notebook.ipynb -o /notebook/notebook.ipynb",
-            ]
+            - bash
+          args:
+            - -c
+            - curl https://raw.githubusercontent.com/stackabletech/demos/main/stacks/jupyterhub-pyspark-hdfs/notebook.ipynb -o /notebook/notebook.ipynb
           volumeMounts:
             - mountPath: /notebook
               name: notebook

--- a/stacks/jupyterhub-pyspark-hdfs/notebook.ipynb
+++ b/stacks/jupyterhub-pyspark-hdfs/notebook.ipynb
@@ -53,7 +53,7 @@
     "#\n",
     "# See: https://issues.apache.org/jira/browse/SPARK-46032\n",
     "#\n",
-    "spark.addArtifacts(\"/stackable/spark/connect/spark-connect_2.12-3.5.7.jar\")"
+    "spark.addArtifacts(\"/stackable/spark/connect/spark-connect-4.0.1.jar\")"
    ]
   },
   {

--- a/stacks/jupyterhub-pyspark-hdfs/notebook.ipynb
+++ b/stacks/jupyterhub-pyspark-hdfs/notebook.ipynb
@@ -53,7 +53,7 @@
     "#\n",
     "# See: https://issues.apache.org/jira/browse/SPARK-46032\n",
     "#\n",
-    "spark.addArtifacts(\"/stackable/spark/connect/spark-connect_2.12-3.5.6.jar\")"
+    "spark.addArtifacts(\"/stackable/spark/connect/spark-connect_2.12-3.5.7.jar\")"
    ]
   },
   {

--- a/stacks/jupyterhub-pyspark-hdfs/spark_connect.yaml
+++ b/stacks/jupyterhub-pyspark-hdfs/spark_connect.yaml
@@ -30,8 +30,8 @@ spec:
   image:
     # Using an image that includes scikit-learn (among other things)
     # because this package needs to be available on the executors.
-    custom: oci.stackable.tech/stackable/spark-connect-client:3.5.7-stackable0.0.0-dev
-    productVersion: 3.5.7
+    custom: oci.stackable.tech/stackable/spark-connect-client:4.0.1-stackable0.0.0-dev
+    productVersion: 4.0.1
     pullPolicy: IfNotPresent
   args:
   server:

--- a/stacks/jupyterhub-pyspark-hdfs/spark_connect.yaml
+++ b/stacks/jupyterhub-pyspark-hdfs/spark_connect.yaml
@@ -30,8 +30,8 @@ spec:
   image:
     # Using an image that includes scikit-learn (among other things)
     # because this package needs to be available on the executors.
-    custom: oci.stackable.tech/stackable/spark-connect-client:3.5.6-stackable0.0.0-dev
-    productVersion: 3.5.6
+    custom: oci.stackable.tech/stackable/spark-connect-client:3.5.7-stackable0.0.0-dev
+    productVersion: 3.5.7
     pullPolicy: IfNotPresent
   args:
   server:


### PR DESCRIPTION

Part of: https://github.com/stackabletech/docker-images/issues/1273

Depends on:

- https://github.com/stackabletech/docker-images/pull/1280
- https://github.com/stackabletech/spark-k8s-operator/pull/610
