### PR TITLE
chore(issue_templates): Add --release dev option to stack install command

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-from-scratch-testing.md
+++ b/.github/ISSUE_TEMPLATE/release-from-scratch-testing.md
@@ -112,5 +112,5 @@ Some stacks are not used by demos, but still need testing in some way.
 You can install the stack via:
 
 ```shell
-stackablectl stack install <STACK_NAME>
+stackablectl stack install <STACK_NAME> --release dev
 ```


### PR DESCRIPTION
This was missed in https://github.com/stackabletech/demos/pull/329 because I originally wrote it for stable to nightly testing.