### PR TITLE
fix: set listener preset to stable-nodes

### DIFF
--- a/stacks/argo-cd-git-ops/applicationsets/stackable-operators.yaml
+++ b/stacks/argo-cd-git-ops/applicationsets/stackable-operators.yaml
@@ -24,7 +24,7 @@ spec:
                 - operator: opensearch
                 - operator: spark-k8s
                 - operator: superset
-                - operator: trinov
+                - operator: trino
                 - operator: zookeeper
           - list:
               elements:


### PR DESCRIPTION
The default is `ephemeral-nodes` which, in combination with the `external-stable` ListenerClass waits for a LoadBalancer, which fails e.g. on local Kind clusters. This PR leaves the ListenerClass as it is but switches the preset to `stable-nodes`, so that NodePort is used instead of LoadBalancer.
Also, I think for a demo it's reasonable to assume stable nodes by default.