### PR TITLE
fix: Data lakehouse demo flow file (25.3)

### DIFF
--- a/demos/data-lakehouse-iceberg-trino-spark/create-nifi-ingestion-job.yaml
+++ b/demos/data-lakehouse-iceberg-trino-spark/create-nifi-ingestion-job.yaml
@@ -67,7 +67,7 @@ data:
     service_login(username=USERNAME, password=PASSWORD)
     print("Logged in")
 
-    response = requests.get("https://raw.githubusercontent.com/stackabletech/demos/refs/heads/main/demos/data-lakehouse-iceberg-trino-spark/LakehouseKafkaIngest.json")
+    response = requests.get("https://raw.githubusercontent.com/stackabletech/demos/refs/heads/release-25.3/demos/data-lakehouse-iceberg-trino-spark/LakehouseKafkaIngest.json")
 
     filename = "/tmp/LakehouseKafkaIngest.json"
     with open(filename, "wb") as f:


### PR DESCRIPTION
Use the NiFi flow file on the `release-25.3` branch instead of `main` in the `data-lakehouse-icebergtrino-spark` demo.

Follow-up to #333.