### PR TITLE
fix: HBase/HDFS demo - bump hbase to latest supported version

### DIFF
--- a/demos/hbase-hdfs-load-cycling-data/create-hfile-and-import-to-hbase.yaml
+++ b/demos/hbase-hdfs-load-cycling-data/create-hfile-and-import-to-hbase.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
         - name: create-hfile-and-import-to-hbase
-          image: oci.stackable.tech/sdp/hbase:2.6.1-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/hbase:2.6.3-stackable0.0.0-dev
           env:
             - name: HADOOP_USER_NAME
               value: stackable


### PR DESCRIPTION
Bump HBase to 2.6.3 (missed previously pre-release)