### PR TITLE
feat: Remove overrides for OpenSearch TLS in logging demo

### DIFF
--- a/stacks/logging/opensearch.yaml
+++ b/stacks/logging/opensearch.yaml
@@ -28,14 +28,6 @@ spec:
         # be created even if enough disk space would be available.
         cluster.routing.allocation.disk.threshold_enabled: "false"
         plugins.security.allow_default_init_securityindex: "true"
-        plugins.security.ssl.transport.enabled: "true"
-        plugins.security.ssl.transport.pemcert_filepath: /stackable/opensearch/config/tls/tls.crt
-        plugins.security.ssl.transport.pemkey_filepath: /stackable/opensearch/config/tls/tls.key
-        plugins.security.ssl.transport.pemtrustedcas_filepath: /stackable/opensearch/config/tls/ca.crt
-        plugins.security.ssl.http.enabled: "true"
-        plugins.security.ssl.http.pemcert_filepath: /stackable/opensearch/config/tls/tls.crt
-        plugins.security.ssl.http.pemkey_filepath: /stackable/opensearch/config/tls/tls.key
-        plugins.security.ssl.http.pemtrustedcas_filepath: /stackable/opensearch/config/tls/ca.crt
     podOverrides:
       spec:
         containers:
@@ -44,28 +36,11 @@ spec:
               - name: security-config
                 mountPath: /stackable/opensearch/config/opensearch-security
                 readOnly: true
-              - name: tls
-                mountPath: /stackable/opensearch/config/tls
-                readOnly: true
         volumes:
           - name: security-config
             secret:
               secretName: opensearch-security-config
               defaultMode: 0o660
-          - name: tls
-            ephemeral:
-              volumeClaimTemplate:
-                metadata:
-                  annotations:
-                    secrets.stackable.tech/class: tls
-                    secrets.stackable.tech/scope: node,pod,service=opensearch,service=opensearch-nodes-default-headless
-                spec:
-                  storageClassName: secrets.stackable.tech
-                  accessModes:
-                    - ReadWriteOnce
-                  resources:
-                    requests:
-                      storage: "1"
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Remove OpenSearch TLS overrides as this is now supported by the operator.

Part of https://github.com/stackabletech/opensearch-operator/issues/61.