### PR TITLE
chore: use new testing-tools image

### DIFF
--- a/demos/airflow-scheduled-job/create-trino-tables.yaml
+++ b/demos/airflow-scheduled-job/create-trino-tables.yaml
@@ -9,7 +9,7 @@ spec:
       serviceAccountName: demo-serviceaccount
       containers:
         - name: create-tables-in-trino
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command: ["bash", "-c", "python -u /tmp/script/script.py"]
           volumeMounts:
             - name: script

--- a/demos/data-lakehouse-iceberg-trino-spark/create-nifi-ingestion-job.yaml
+++ b/demos/data-lakehouse-iceberg-trino-spark/create-nifi-ingestion-job.yaml
@@ -22,7 +22,7 @@ spec:
               kubectl wait --for=condition=ready --timeout=30m pod -l app.kubernetes.io/instance=kafka,app.kubernetes.io/name=kafka
       containers:
         - name: create-nifi-ingestion-job
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools/nifi:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/data-lakehouse-iceberg-trino-spark/create-trino-tables.yaml
+++ b/demos/data-lakehouse-iceberg-trino-spark/create-trino-tables.yaml
@@ -20,7 +20,7 @@ spec:
               kubectl wait --for=condition=complete --timeout=30m job/load-test-data
       containers:
         - name: create-tables-in-trino
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools/trino:0.3.0-stackable0.0.0-dev
           command: ["bash", "-c", "python -u /tmp/script/script.py"]
           volumeMounts:
             - name: script

--- a/demos/data-lakehouse-iceberg-trino-spark/setup-superset.yaml
+++ b/demos/data-lakehouse-iceberg-trino-spark/setup-superset.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: setup-superset
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/end-to-end-security/create-spark-report.yaml
+++ b/demos/end-to-end-security/create-spark-report.yaml
@@ -12,7 +12,7 @@ spec:
       serviceAccountName: demo-serviceaccount
       initContainers:
         - name: wait-for-trino-tables
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo
@@ -23,7 +23,7 @@ spec:
               kubectl wait --timeout=30m --for=condition=complete job/create-tables-in-trino
       containers:
         - name: create-spark-report
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/end-to-end-security/create-trino-tables.yaml
+++ b/demos/end-to-end-security/create-trino-tables.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: create-tables-in-trino
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools/trino:0.3.0-stackable0.0.0-dev
           command: ["bash", "-c", "python -u /tmp/script/script.py"]
           volumeMounts:
             - name: script

--- a/demos/nifi-kafka-druid-earthquake-data/create-druid-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-earthquake-data/create-druid-ingestion-job.yaml
@@ -22,7 +22,7 @@ spec:
               kubectl wait --for=condition=Ready pod/druid-coordinator-default-0 --timeout=30m
       containers:
         - name: create-druid-ingestion-job
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/nifi-kafka-druid-earthquake-data/create-nifi-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-earthquake-data/create-nifi-ingestion-job.yaml
@@ -22,7 +22,7 @@ spec:
               kubectl wait --for=condition=Ready pod/nifi-node-default-0 --timeout=30m
       containers:
         - name: create-nifi-ingestion-job
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools/nifi:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/nifi-kafka-druid-earthquake-data/setup-superset.yaml
+++ b/demos/nifi-kafka-druid-earthquake-data/setup-superset.yaml
@@ -22,7 +22,7 @@ spec:
               kubectl wait --for=condition=Ready pod/superset-node-default-0 --timeout=30m
       containers:
         - name: setup-superset
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/nifi-kafka-druid-water-level-data/create-druid-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-water-level-data/create-druid-ingestion-job.yaml
@@ -22,7 +22,7 @@ spec:
               kubectl wait --for=condition=Ready pod/druid-coordinator-default-0 --timeout=30m
       containers:
         - name: create-druid-ingestion-job
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/nifi-kafka-druid-water-level-data/create-nifi-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-water-level-data/create-nifi-ingestion-job.yaml
@@ -22,7 +22,7 @@ spec:
               kubectl wait --for=condition=Ready pod/nifi-node-default-0 --timeout=30m
       containers:
         - name: create-nifi-ingestion-job
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools/nifi:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/nifi-kafka-druid-water-level-data/setup-superset.yaml
+++ b/demos/nifi-kafka-druid-water-level-data/setup-superset.yaml
@@ -22,7 +22,7 @@ spec:
               kubectl wait --for=condition=Ready pod/superset-node-default-0 --timeout=30m
       containers:
         - name: setup-superset
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/signal-processing/create-nifi-ingestion-job.yaml
+++ b/demos/signal-processing/create-nifi-ingestion-job.yaml
@@ -28,7 +28,7 @@ spec:
               kubectl wait --for=condition=Ready pod/nifi-node-default-0 --timeout=30m
       containers:
         - name: create-nifi-ingestion-job
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools/nifi:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/spark-k8s-anomaly-detection-taxi-data/create-spark-anomaly-detection-job.yaml
+++ b/demos/spark-k8s-anomaly-detection-taxi-data/create-spark-anomaly-detection-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-testdata
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo
@@ -19,7 +19,7 @@ spec:
               kubectl wait --for=condition=complete --timeout=30m job/load-ny-taxi-data
       containers:
         - name: create-spark-anomaly-detection-job
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/spark-k8s-anomaly-detection-taxi-data/setup-superset.yaml
+++ b/demos/spark-k8s-anomaly-detection-taxi-data/setup-superset.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: setup-superset
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -euo

--- a/demos/trino-taxi-data/create-table-in-trino.yaml
+++ b/demos/trino-taxi-data/create-table-in-trino.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: create-ny-taxi-data-table-in-trino
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools/trino:0.3.0-stackable0.0.0-dev
           command: ["bash", "-c", "python -u /tmp/script/script.py"]
           volumeMounts:
             - name: script

--- a/demos/trino-taxi-data/setup-superset.yaml
+++ b/demos/trino-taxi-data/setup-superset.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: setup-superset
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command: ["bash", "-c", "curl -o superset-assets.zip https://raw.githubusercontent.com/stackabletech/demos/main/demos/trino-taxi-data/superset-assets.zip && python -u /tmp/script/script.py"]
           volumeMounts:
             - name: script

--- a/stacks/_templates/keycloak.yaml
+++ b/stacks/_templates/keycloak.yaml
@@ -48,7 +48,7 @@ spec:
             - name: tls
               mountPath: /tls/
         - name: create-auth-class
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/stacks/end-to-end-security/setup-postgresql.yaml
+++ b/stacks/end-to-end-security/setup-postgresql.yaml
@@ -9,7 +9,7 @@ spec:
       initContainers:
         # The postgres image does not contain curl or wget...
         - name: download-dump
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command:
             - bash
             - -c

--- a/stacks/end-to-end-security/superset.yaml
+++ b/stacks/end-to-end-security/superset.yaml
@@ -24,7 +24,7 @@ spec:
       spec:
         initContainers:
           - name: wait-for-setup-db-job
-            image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+            image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
             command:
               - bash
               - -c

--- a/stacks/jupyterhub-keycloak/keycloak.yaml
+++ b/stacks/jupyterhub-keycloak/keycloak.yaml
@@ -50,7 +50,7 @@ spec:
               mountPath: /tls/
         - name: create-configmap
           resources: {}
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/stacks/logging/setup-opensearch-dashboards.yaml
+++ b/stacks/logging/setup-opensearch-dashboards.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: setup-opensearch-dashboards
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           env:
             - name: OPEN_SEARCH_ADMIN_PASSWORD
               valueFrom:


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/767

This uses the new oci.stackable.tech/sdp/testing-tools image (0.3.0).

I installed the `spark-k8s-anomaly-detection-taxi-data` and `nifi-kafka-druid-water-level-data` demo (dev release) and checked whether the containers complete successfully, which they did.