### PR TITLE
chore: Bump NiFi to 2.7.2

### DIFF
--- a/.github/workflows/dev_nifi.yaml
+++ b/.github/workflows/dev_nifi.yaml
@@ -25,5 +25,5 @@ jobs:
       image-name: nifi
       # TODO (@NickLarsenNZ): Use a versioned image with stackable0.0.0-dev or stackableXX.X.X so that
       # the demo is reproducable for the release and it will be automatically replaced for the release branch.
-      image-version: 2.6.0-postgresql
+      image-version: 2.7.2-postgresql
       containerfile-path: demos/signal-processing/Dockerfile-nifi

--- a/demos/signal-processing/Dockerfile-nifi
+++ b/demos/signal-processing/Dockerfile-nifi
@@ -1,4 +1,4 @@
-FROM oci.stackable.tech/sdp/nifi:2.6.0-stackable0.0.0-dev
+FROM oci.stackable.tech/sdp/nifi:2.7.2-stackable0.0.0-dev
 
 # This is the postgresql JDBC driver from https://jdbc.postgresql.org/download/
 # There appear to be no signatures to validate against 😬

--- a/stacks/data-lakehouse-iceberg-trino-spark/nifi.yaml
+++ b/stacks/data-lakehouse-iceberg-trino-spark/nifi.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nifi
 spec:
   image:
-    productVersion: 2.6.0
+    productVersion: 2.7.2
   clusterConfig:
     authentication:
       - authenticationClass: nifi-admin-credentials

--- a/stacks/nifi-kafka-druid-superset-s3/nifi.yaml
+++ b/stacks/nifi-kafka-druid-superset-s3/nifi.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nifi
 spec:
   image:
-    productVersion: 2.6.0
+    productVersion: 2.7.2
   clusterConfig:
     authentication:
       - authenticationClass: nifi-admin-credentials

--- a/stacks/signal-processing/nifi.yaml
+++ b/stacks/signal-processing/nifi.yaml
@@ -5,10 +5,10 @@ metadata:
   name: nifi
 spec:
   image:
-    productVersion: 2.6.0
+    productVersion: 2.7.2
     # TODO (@NickLarsenNZ): Use a versioned image with stackable0.0.0-dev or stackableXX.X.X so that
     # the demo is reproducable for the release and it will be automatically replaced for the release branch.
-    custom: oci.stackable.tech/demos/nifi:2.6.0-postgresql
+    custom: oci.stackable.tech/demos/nifi:2.7.2-postgresql
     # pullPolicy: IfNotPresent
   clusterConfig:
     authentication:


### PR DESCRIPTION
Part of github.com/stackabletech/docker-images/issues/1377

Hard to test, as the kafka is broken for unrelated reasons (KRaft bug).

As far as I understood the needed image will be build by CI on merge into main.
So I would optimistically merge and test afterwards.