### PR TITLE
Configure the OpenSearch security in the cluster spec

### DIFF
--- a/stacks/logging/opensearch.yaml
+++ b/stacks/logging/opensearch.yaml
@@ -7,6 +7,53 @@ spec:
     productVersion: {{ opensearchVersion }}
     pullPolicy: IfNotPresent
   clusterConfig:
+    security:
+      settings:
+        config:
+          managedBy: API
+          content:
+            value:
+              _meta:
+                type: config
+                config_version: 2
+              config:
+                dynamic:
+                  authc:
+                    basic_internal_auth_domain:
+                      description: Authenticate via HTTP Basic against internal users database
+                      http_enabled: true
+                      transport_enabled: true
+                      order: 1
+                      http_authenticator:
+                        type: basic
+                        challenge: true
+                      authentication_backend:
+                        type: intern
+                  authz: {}
+                  kibana:
+                    multitenancy_enabled: false
+        internalUsers:
+          managedBy: API
+          content:
+            valueFrom:
+              secretKeyRef:
+                name: opensearch-security-config
+                key: internal_users.yml
+        rolesMapping:
+          managedBy: API
+          content:
+            value:
+              _meta:
+                type: rolesmapping
+                config_version: 2
+              all_access:
+                reserved: false
+                backend_roles:
+                  - admin
+              kibana_server:
+                reserved: true
+                users:
+                  - kibanaserver
     vectorAggregatorConfigMapName: vector-aggregator-discovery
   nodes:
     config:
@@ -27,69 +74,12 @@ spec:
         # `cluster.routing.allocation.disk.watermark.high` is reached the security index can't
         # be created even if enough disk space would be available.
         cluster.routing.allocation.disk.threshold_enabled: "false"
-        plugins.security.allow_default_init_securityindex: "true"
-    podOverrides:
-      spec:
-        containers:
-          - name: opensearch
-            volumeMounts:
-              - name: security-config
-                mountPath: /stackable/opensearch/config/opensearch-security
-                readOnly: true
-        volumes:
-          - name: security-config
-            secret:
-              secretName: opensearch-security-config
-              defaultMode: 0o660
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: opensearch-security-config
 stringData:
-  action_groups.yml: |
-    ---
-    _meta:
-      type: actiongroups
-      config_version: 2
-  allowlist.yml: |
-    ---
-    _meta:
-      type: allowlist
-      config_version: 2
-
-    config:
-      enabled: false
-  audit.yml: |
-    ---
-    _meta:
-      type: audit
-      config_version: 2
-
-    config:
-      enabled: false
-  config.yml: |
-    ---
-    _meta:
-      type: config
-      config_version: 2
-
-    config:
-      dynamic:
-        authc:
-          basic_internal_auth_domain:
-            description: Authenticate via HTTP Basic against internal users database
-            http_enabled: true
-            transport_enabled: true
-            order: 1
-            http_authenticator:
-              type: basic
-              challenge: true
-            authentication_backend:
-              type: intern
-        authz: {}
-        kibana:
-          multitenancy_enabled: false
   internal_users.yml: |
     ---
     _meta:
@@ -107,36 +97,6 @@ stringData:
       hash: {{ bcrypt(password=openSearchDashboardPassword) }}
       reserved: true
       description: OpenSearch Dashboards user
-  nodes_dn.yml: |
-    ---
-    _meta:
-      type: nodesdn
-      config_version: 2
-  roles.yml: |
-    ---
-    _meta:
-      type: roles
-      config_version: 2
-  roles_mapping.yml: |
-    ---
-    _meta:
-      type: rolesmapping
-      config_version: 2
-
-    all_access:
-      reserved: false
-      backend_roles:
-        - admin
-
-    kibana_server:
-      reserved: true
-      users:
-        - kibanaserver
-  tenants.yml: |
-    ---
-    _meta:
-      type: tenants
-      config_version: 2
 ---
 apiVersion: v1
 kind: Secret

--- a/stacks/opensearch-rag/opensearch.yaml
+++ b/stacks/opensearch-rag/opensearch.yaml
@@ -6,6 +6,54 @@ spec:
   image:
     productVersion: {{ opensearchVersion }}
     pullPolicy: IfNotPresent
+  clusterConfig:
+    security:
+      settings:
+        config:
+          managedBy: API
+          content:
+            value:
+              _meta:
+                type: config
+                config_version: 2
+              config:
+                dynamic:
+                  authc:
+                    basic_internal_auth_domain:
+                      description: Authenticate via HTTP Basic against internal users database
+                      http_enabled: true
+                      transport_enabled: true
+                      order: 1
+                      http_authenticator:
+                        type: basic
+                        challenge: true
+                      authentication_backend:
+                        type: intern
+                  authz: {}
+                  kibana:
+                    multitenancy_enabled: false
+        internalUsers:
+          managedBy: API
+          content:
+            valueFrom:
+              secretKeyRef:
+                name: opensearch-security-config
+                key: internal_users.yml
+        rolesMapping:
+          managedBy: API
+          content:
+            value:
+              _meta:
+                type: rolesmapping
+                config_version: 2
+              all_access:
+                reserved: false
+                backend_roles:
+                  - admin
+              kibana_server:
+                reserved: true
+                users:
+                  - kibanaserver
   nodes:
     roleGroups:
       default:
@@ -28,70 +76,12 @@ spec:
         node.store.allow_mmap: "false"
         # Disable the disk allocation decider to prevent issues with security index creation
         cluster.routing.allocation.disk.threshold_enabled: "false"
-        # Allow automatic initialization of security index
-        plugins.security.allow_default_init_securityindex: "true"
-    podOverrides:
-      spec:
-        containers:
-          - name: opensearch
-            volumeMounts:
-              - name: security-config
-                mountPath: /stackable/opensearch/config/opensearch-security
-                readOnly: true
-        volumes:
-          - name: security-config
-            secret:
-              secretName: opensearch-security-config
-              defaultMode: 0o660
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: opensearch-security-config
 stringData:
-  action_groups.yml: |
-    ---
-    _meta:
-      type: actiongroups
-      config_version: 2
-  allowlist.yml: |
-    ---
-    _meta:
-      type: allowlist
-      config_version: 2
-
-    config:
-      enabled: false
-  audit.yml: |
-    ---
-    _meta:
-      type: audit
-      config_version: 2
-
-    config:
-      enabled: false
-  config.yml: |
-    ---
-    _meta:
-      type: config
-      config_version: 2
-
-    config:
-      dynamic:
-        authc:
-          basic_internal_auth_domain:
-            description: Authenticate via HTTP Basic against internal users database
-            http_enabled: true
-            transport_enabled: true
-            order: 1
-            http_authenticator:
-              type: basic
-              challenge: true
-            authentication_backend:
-              type: intern
-        authz: {}
-        kibana:
-          multitenancy_enabled: false
   internal_users.yml: |
     ---
     _meta:
@@ -109,36 +99,6 @@ stringData:
       hash: {{ bcrypt(password=openSearchDashboardPassword) }}
       reserved: true
       description: OpenSearch Dashboards user
-  nodes_dn.yml: |
-    ---
-    _meta:
-      type: nodesdn
-      config_version: 2
-  roles.yml: |
-    ---
-    _meta:
-      type: roles
-      config_version: 2
-  roles_mapping.yml: |
-    ---
-    _meta:
-      type: rolesmapping
-      config_version: 2
-
-    all_access:
-      reserved: false
-      backend_roles:
-        - admin
-
-    kibana_server:
-      reserved: true
-      users:
-        - kibanaserver
-  tenants.yml: |
-    ---
-    _meta:
-      type: tenants
-      config_version: 2
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Configure the OpenSearch security plugin in the OpenSearchCluster specifications of the logging stack and the opensearch-rag demo.

The stack and demo were successfully tested locally.

Part of stackabletech/opensearch-operator#43