### PR TITLE
fix: Airflow demo fixes pre-26.3

### DIFF
--- a/demos/airflow-scheduled-job/create-trino-tables.yaml
+++ b/demos/airflow-scheduled-job/create-trino-tables.yaml
@@ -9,7 +9,7 @@ spec:
       serviceAccountName: demo-serviceaccount
       containers:
         - name: create-tables-in-trino
-          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools/trino:0.3.0-stackable0.0.0-dev
           command: ["bash", "-c", "python -u /tmp/script/script.py"]
           volumeMounts:
             - name: script

--- a/docs/modules/demos/pages/airflow-scheduled-job.adoc
+++ b/docs/modules/demos/pages/airflow-scheduled-job.adoc
@@ -284,7 +284,7 @@ The patch also sets some environment variables that can be used to change the fr
 [source,yaml]
 ----
 ---
-apiVersion: airflow.stackable.tech/v1alpha1
+apiVersion: airflow.stackable.tech/v1alpha2
 kind: AirflowCluster
 metadata:
   name: airflow
@@ -294,8 +294,6 @@ spec:
       - name: airflow-dags
         mountPath: /dags/dag_factory.py
         subPath: dag_factory.py
-      - name: kafka-tls-pem
-        mountPath: /stackable/kafka-tls-pem
   webservers:
     roleGroups:
       default:

--- a/stacks/airflow/airflow.yaml
+++ b/stacks/airflow/airflow.yaml
@@ -1,6 +1,6 @@
 ---
 # {% raw %}
-apiVersion: airflow.stackable.tech/v1alpha1
+apiVersion: airflow.stackable.tech/v1alpha2
 kind: AirflowCluster
 metadata:
   name: airflow

--- a/stacks/airflow/airflow.yaml
+++ b/stacks/airflow/airflow.yaml
@@ -74,7 +74,7 @@ spec:
       spec:
         containers:
           - name: airflow
-            image: oci.stackable.tech/sdp/airflow:3.0.6-stackable0.0.0-dev
+            image: oci.stackable.tech/sdp/airflow:3.1.6-stackable0.0.0-dev
             imagePullPolicy: IfNotPresent
             env:
               - name: NAMESPACE
@@ -102,7 +102,7 @@ spec:
       spec:
         containers:
           - name: base
-            image: oci.stackable.tech/sdp/airflow:3.0.6-stackable0.0.0-dev
+            image: oci.stackable.tech/sdp/airflow:3.1.6-stackable0.0.0-dev
             imagePullPolicy: IfNotPresent
             env:
               - name: AWS_SECRET_ACCESS_KEY

--- a/stacks/airflow/patch_airflow.yaml
+++ b/stacks/airflow/patch_airflow.yaml
@@ -9,8 +9,6 @@ spec:
       - name: airflow-dags
         mountPath: /dags/dag_factory.py
         subPath: dag_factory.py
-      - name: tls-pem
-        mountPath: /stackable/kafka-tls-pem
   webservers:
     roleGroups:
       default:

--- a/stacks/airflow/patch_airflow.yaml
+++ b/stacks/airflow/patch_airflow.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: airflow.stackable.tech/v1alpha1
+apiVersion: airflow.stackable.tech/v1alpha2
 kind: AirflowCluster
 metadata:
   name: airflow
@@ -9,7 +9,7 @@ spec:
       - name: airflow-dags
         mountPath: /dags/dag_factory.py
         subPath: dag_factory.py
-      - name: kafka-tls-pem
+      - name: tls-pem
         mountPath: /stackable/kafka-tls-pem
   webservers:
     roleGroups:


### PR DESCRIPTION
Updated two references to Airflow 3.1.6 that were missed.
Refer to trino test image as that contains the `trino` package.
Removed mount in the patch manifest (and updated docs).