### PR TITLE
fix(demos/argo-cd-git-ops): Use 26.3.0 release for operators

### DIFF
--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -36,7 +36,7 @@ stacks:
       - name: stackableReleaseVersion
         description: The Stackable release to be installed via Argo. This replaces the demo `stackableRelease` parameter.
         # TODO(@maltesander): Must be adapted in case of release !
-        default: 0.0.0-dev
+        default: 26.3.0
       - name: argocdAdminPassword
         description: Password of the ArgoCD admin user.
         # generated via: `htpasswd -nbBC 10 "" adminadmin | tr -d ':\n'`


### PR DESCRIPTION
This likely was missed by the automated script.