### PR TITLE
fix(data-lakehouse-iceberg-trino-spark): Bump Kafka to 4.1.1

### DIFF
--- a/demos/data-lakehouse-iceberg-trino-spark/create-spark-ingestion-job.yaml
+++ b/demos/data-lakehouse-iceberg-trino-spark/create-spark-ingestion-job.yaml
@@ -26,7 +26,7 @@ spec:
               echo 'Waiting for all nifi instances to be ready'
               kubectl wait --for=condition=ready --timeout=30m pod -l app.kubernetes.io/name=nifi,app.kubernetes.io/instance=nifi
         - name: wait-for-kafka-topics
-          image: oci.stackable.tech/sdp/kafka:4.1.0-stackable26.3.0
+          image: oci.stackable.tech/sdp/kafka:4.1.1-stackable26.3.0
           command:
             - bash
             - -euo


### PR DESCRIPTION
Backport of https://github.com/stackabletech/demos/pull/394