### PR TITLE
fix: Observability stack now works

### DIFF
--- a/stacks/observability/grafana.yaml
+++ b/stacks/observability/grafana.yaml
@@ -22,14 +22,14 @@ options:
       datasources:
         - name: Loki
           type: loki
-          url: http://loki:3100
+          url: http://loki.{{ NAMESPACE }}.svc.cluster.local:3100
           access: proxy
           isDefault: false
           jsonData:
             tlsAuthWithCACert: false
         - name: Tempo
           type: tempo
-          url: http://tempo:3200
+          url: http://tempo.{{ NAMESPACE }}.svc.cluster.local:3200
           access: proxy
           isDefault: false
           jsonData:

--- a/stacks/observability/grafana.yaml
+++ b/stacks/observability/grafana.yaml
@@ -29,7 +29,7 @@ options:
             tlsAuthWithCACert: false
         - name: Tempo
           type: tempo
-          url: http://tempo:3100
+          url: http://tempo:3200
           access: proxy
           isDefault: false
           jsonData:

--- a/stacks/observability/opentelemetry-collector-deployment.yaml
+++ b/stacks/observability/opentelemetry-collector-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       debug: {}
         # verbosity: detailed
       otlp/jaeger:
-        endpoint: jaeger-collector:4317
+        endpoint: jaeger:4317
         tls:
           insecure: true
       otlp/tempo:

--- a/stacks/observability/opentelemetry-collector-deployment.yaml
+++ b/stacks/observability/opentelemetry-collector-deployment.yaml
@@ -38,15 +38,15 @@ spec:
       debug: {}
         # verbosity: detailed
       otlp/jaeger:
-        endpoint: jaeger:4317
+        endpoint: jaeger.{{ NAMESPACE }}.svc.cluster.local:4317
         tls:
           insecure: true
       otlp/tempo:
-        endpoint: tempo:4317
+        endpoint: tempo.{{ NAMESPACE }}.svc.cluster.local:4317
         tls:
           insecure: true
       otlphttp/loki:
-        endpoint: http://loki:3100/otlp
+        endpoint: http://loki.{{ NAMESPACE }}.svc.cluster.local:3100/otlp
         tls:
           insecure: true
       #     auth:

--- a/stacks/observability/opentelemetry-collector-sidecar.yaml
+++ b/stacks/observability/opentelemetry-collector-sidecar.yaml
@@ -36,15 +36,15 @@ spec:
       debug: {}
         # verbosity: detailed
       otlp/jaeger:
-        endpoint: jaeger:4317
+        endpoint: jaeger.{{ NAMESPACE }}.svc.cluster.local:4317
         tls:
           insecure: true
       otlp/tempo:
-        endpoint: tempo:4317
+        endpoint: tempo.{{ NAMESPACE }}.svc.cluster.local:4317
         tls:
           insecure: true
       otlphttp/loki:
-        endpoint: http://loki:3100/otlp
+        endpoint: http://loki.{{ NAMESPACE }}.svc.cluster.local:3100/otlp
         tls:
           insecure: true
       #     auth:

--- a/stacks/observability/opentelemetry-collector-sidecar.yaml
+++ b/stacks/observability/opentelemetry-collector-sidecar.yaml
@@ -36,7 +36,7 @@ spec:
       debug: {}
         # verbosity: detailed
       otlp/jaeger:
-        endpoint: jaeger-collector:4317
+        endpoint: jaeger:4317
         tls:
           insecure: true
       otlp/tempo:

--- a/stacks/stacks-v2.yaml
+++ b/stacks/stacks-v2.yaml
@@ -104,7 +104,8 @@ stacks:
         default: 3.4.0
       - name: stackableReleaseVersion
         description: The Stackable release to be used for the OpenSearch Dashboards image tag
-        default: 0.0.0-dev
+        # TODO (@NickLarsenNZ): Consider using renovate to bump the SDP versions at release branch time.
+        default: 26.3.0
   observability:
     description: >-
       An observability stack with auto-injection of the opentelemetry-collector sidecar to receive traces/logs/metrics via OTLP, and send them to Jaeger/Tempo/Loki.
@@ -688,7 +689,8 @@ stacks:
         default: 3.4.0
       - name: stackableReleaseVersion
         description: The Stackable release to be used for the OpenSearch Dashboards image tag
-        default: 0.0.0-dev
+        # TODO (@NickLarsenNZ): Consider using renovate to bump the SDP versions at release branch time.
+        default: 26.3.0
       - name: jupyterLabToken
         description: Token for JupyterLab UI access
         default: adminadmin


### PR DESCRIPTION
Part of https://github.com/stackabletech/demos/issues/372

Same change for main here: https://github.com/stackabletech/demos/pull/399

> [!TIP]
> Once https://github.com/stackabletech/stackable-cockpit/pull/440 is released, testing of this will be far more automated.
>
> I realise it isn't clear as to why, but _trust me bro_.
> tl;dr: Local mess becomes organised and committed.
> Happy to discuss why if anyone is interested.

- Tempo uses port 3200 for querying (eg: from Grafana) after a chart update.
- Jaeger changed the name of the service.
- My local testing (mess) deploys to a different namespace, and relies on OpenTelemetryCollector having FQDNs in their configs.
- I also noticed a `0.0.0-dev` reference didn't get picked up by the release script. See commit message for an idea.

> [!NOTE]
> This PR has been tested.