### PR TITLE
fix: Observability stack now works

### DIFF
--- a/stacks/observability/grafana.yaml
+++ b/stacks/observability/grafana.yaml
@@ -30,14 +30,14 @@ options:
       datasources:
         - name: Loki
           type: loki
-          url: http://loki:3100
+          url: http://loki.{{ NAMESPACE }}.svc.cluster.local:3100
           access: proxy
           isDefault: false
           jsonData:
             tlsAuthWithCACert: false
         - name: Tempo
           type: tempo
-          url: http://tempo:3200
+          url: http://tempo.{{ NAMESPACE }}.svc.cluster.local:3200
           access: proxy
           isDefault: false
           jsonData:

--- a/stacks/observability/grafana.yaml
+++ b/stacks/observability/grafana.yaml
@@ -37,7 +37,7 @@ options:
             tlsAuthWithCACert: false
         - name: Tempo
           type: tempo
-          url: http://tempo:3100
+          url: http://tempo:3200
           access: proxy
           isDefault: false
           jsonData:

--- a/stacks/observability/opentelemetry-collector-deployment.yaml
+++ b/stacks/observability/opentelemetry-collector-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       debug: {}
         # verbosity: detailed
       otlp/jaeger:
-        endpoint: jaeger-collector:4317
+        endpoint: jaeger:4317
         tls:
           insecure: true
       otlp/tempo:

--- a/stacks/observability/opentelemetry-collector-deployment.yaml
+++ b/stacks/observability/opentelemetry-collector-deployment.yaml
@@ -38,15 +38,15 @@ spec:
       debug: {}
         # verbosity: detailed
       otlp/jaeger:
-        endpoint: jaeger:4317
+        endpoint: jaeger.{{ NAMESPACE }}.svc.cluster.local:4317
         tls:
           insecure: true
       otlp/tempo:
-        endpoint: tempo:4317
+        endpoint: tempo.{{ NAMESPACE }}.svc.cluster.local:4317
         tls:
           insecure: true
       otlphttp/loki:
-        endpoint: http://loki:3100/otlp
+        endpoint: http://loki.{{ NAMESPACE }}.svc.cluster.local:3100/otlp
         tls:
           insecure: true
       #     auth:

--- a/stacks/observability/opentelemetry-collector-sidecar.yaml
+++ b/stacks/observability/opentelemetry-collector-sidecar.yaml
@@ -36,15 +36,15 @@ spec:
       debug: {}
         # verbosity: detailed
       otlp/jaeger:
-        endpoint: jaeger:4317
+        endpoint: jaeger.{{ NAMESPACE }}.svc.cluster.local:4317
         tls:
           insecure: true
       otlp/tempo:
-        endpoint: tempo:4317
+        endpoint: tempo.{{ NAMESPACE }}.svc.cluster.local:4317
         tls:
           insecure: true
       otlphttp/loki:
-        endpoint: http://loki:3100/otlp
+        endpoint: http://loki.{{ NAMESPACE }}.svc.cluster.local:3100/otlp
         tls:
           insecure: true
       #     auth:

--- a/stacks/observability/opentelemetry-collector-sidecar.yaml
+++ b/stacks/observability/opentelemetry-collector-sidecar.yaml
@@ -36,7 +36,7 @@ spec:
       debug: {}
         # verbosity: detailed
       otlp/jaeger:
-        endpoint: jaeger-collector:4317
+        endpoint: jaeger:4317
         tls:
           insecure: true
       otlp/tempo:


### PR DESCRIPTION
Sibling PR to https://github.com/stackabletech/demos/pull/398

> [!TIP]
> Once https://github.com/stackabletech/stackable-cockpit/pull/440 is released, testing of this will be far more automated.
>
> See test procedure further below for now.

- Tempo uses port 3200 for querying (eg: from Grafana) after a chart update.
- Jaeger changed the name of the service.
- My local testing (mess) deploys to a different namespace, and relies on OpenTelemetryCollector having FQDNs in their configs.

<details>
<summary>Test procedure</summary>

Drop the URL prefix for the stack in `stacks-v2.yaml` (in case of local changes), then run:

```shell
stackablectl stack --stack-file=./stacks/stacks-v2.yaml install observability
```

Then, with `values.yaml`:

_yes overkill with anchors, but I used it with other operators too - those are removed for brevity, but the anchors seemed useful in future._

```yaml
# See: https://github.com/open-telemetry/opentelemetry-operator
otelSidecarAnnotations: &otel-sidecar-annotations
  sidecar.opentelemetry.io/inject: default/otel-collector-grpc

# See: https://docs.stackable.tech/home/stable/concepts/observability/telemetry/
telemetry: &operator-telemetry
  consoleLog:
    level: warn
  otelLogExporter:
    enabled: true
    level: info
  otelTraceExporter:
    enabled: true
    level: info

instrumented-operator: &instrumented-operator
  podAnnotations:
    <<: *otel-sidecar-annotations
  telemetry:
    <<: *operator-telemetry

trino-operator:
  <<: *instrumented-operator
```

Install an operator with OTLP logs/traces:

```shell
stackablectl operator install --operator-values=values.yaml trino
```

Then create a Trino Cluster to generate some logs/traces.

```sh
kubectl apply -f -
# Press CTRL-D after pasting the below
```

```yaml
---
apiVersion: trino.stackable.tech/v1alpha1
kind: TrinoCluster
metadata:
  name: simple-trino
spec:
  image:
    productVersion: "479"
  clusterConfig:
    catalogLabelSelector:
      matchLabels:
        trino: simple-trino
  coordinators:
    roleConfig:
      listenerClass: external-unstable
    roleGroups:
      default:
        replicas: 1
  workers:
    roleGroups:
      default:
        replicas: 1
```

Then check that there are trino-operator logs and traces in Grafana.

</details>
