### PR TITLE
fix(demos): use updated secret to setup Superset in demos

### DIFF
--- a/demos/data-lakehouse-iceberg-trino-spark/setup-superset.yaml
+++ b/demos/data-lakehouse-iceberg-trino-spark/setup-superset.yaml
@@ -31,7 +31,7 @@ spec:
             name: setup-superset-script
         - name: superset-credentials
           secret:
-            secretName: superset-credentials
+            secretName: superset-admin-credentials
         - name: trino-users
           secret:
             secretName: trino-users

--- a/demos/nifi-kafka-druid-earthquake-data/setup-superset.yaml
+++ b/demos/nifi-kafka-druid-earthquake-data/setup-superset.yaml
@@ -42,7 +42,7 @@ spec:
             name: setup-superset-script
         - name: superset-credentials
           secret:
-            secretName: superset-credentials
+            secretName: superset-admin-credentials
       restartPolicy: OnFailure
   backoffLimit: 50
 ---

--- a/demos/nifi-kafka-druid-water-level-data/setup-superset.yaml
+++ b/demos/nifi-kafka-druid-water-level-data/setup-superset.yaml
@@ -42,7 +42,7 @@ spec:
             name: setup-superset-script
         - name: superset-credentials
           secret:
-            secretName: superset-credentials
+            secretName: superset-admin-credentials
       restartPolicy: OnFailure
   backoffLimit: 50
 ---

--- a/demos/spark-k8s-anomaly-detection-taxi-data/setup-superset.yaml
+++ b/demos/spark-k8s-anomaly-detection-taxi-data/setup-superset.yaml
@@ -30,7 +30,7 @@ spec:
             name: setup-superset-script
         - name: superset-credentials
           secret:
-            secretName: superset-credentials
+            secretName: superset-admin-credentials
         - name: trino-users
           secret:
             secretName: trino-users

--- a/demos/trino-taxi-data/setup-superset.yaml
+++ b/demos/trino-taxi-data/setup-superset.yaml
@@ -23,7 +23,7 @@ spec:
             name: setup-superset-script
         - name: superset-credentials
           secret:
-            secretName: superset-credentials
+            secretName: superset-admin-credentials
         - name: trino-users
           secret:
             secretName: trino-users


### PR DESCRIPTION
This change updates the secret for setting up Superset in demos, as a follow up to https://github.com/stackabletech/demos/pull/400