### PR TITLE
chore: bump kafka version to 4.2.1

### DIFF
--- a/stacks/airflow/kafka.yaml
+++ b/stacks/airflow/kafka.yaml
@@ -14,7 +14,7 @@ metadata:
   name: kafka
 spec:
   image:
-    productVersion: 4.1.1
+    productVersion: 4.2.1
   clusterConfig:
     tls:
       serverSecretClass: tls

--- a/stacks/data-lakehouse-iceberg-trino-spark/kafka.yaml
+++ b/stacks/data-lakehouse-iceberg-trino-spark/kafka.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kafka
 spec:
   image:
-    productVersion: 4.1.1
+    productVersion: 4.2.1
   clusterConfig:
     authentication:
       - authenticationClass: kafka-client-tls

--- a/stacks/nifi-kafka-druid-superset-s3/druid.yaml
+++ b/stacks/nifi-kafka-druid-superset-s3/druid.yaml
@@ -8,12 +8,11 @@ spec:
     productVersion: 35.0.1
   clusterConfig:
     zookeeperConfigMapName: druid-znode
-    metadataStorageDatabase:
-      dbType: postgresql
-      connString: jdbc:postgresql://postgresql-druid/druid
-      host: postgresql-druid
-      port: 5432
-      credentialsSecret: druid-db-credentials
+    metadataDatabase:
+      postgresql:
+        host: postgresql-druid
+        database: druid
+        credentialsSecretName: druid-db-credentials
     deepStorage:
       s3:
         bucket:

--- a/stacks/nifi-kafka-druid-superset-s3/kafka.yaml
+++ b/stacks/nifi-kafka-druid-superset-s3/kafka.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kafka
 spec:
   image:
-    productVersion: 4.1.1
+    productVersion: 4.2.1
   clusterConfig:
     authentication:
       - authenticationClass: kafka-client-tls


### PR DESCRIPTION
NOTE: had to update Druid database connections too (left the version as it was).

Part of https://github.com/stackabletech/docker-images/issues/1497

