### PR TITLE
fix: Pin Superset SECRET_KEY in end-to-end-security stack

### DIFF
--- a/stacks/end-to-end-security/superset.yaml
+++ b/stacks/end-to-end-security/superset.yaml
@@ -1,4 +1,14 @@
 ---
+# The Superset metadata database is restored from postgres_superset_dump.sql (see
+# setup-postgresql.yaml), which contains rows (e.g. the Trino database connection
+# password) encrypted with the SECRET_KEY below.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: superset-secret-key
+stringData:
+  SECRET_KEY: supersetSecretKey
+---
 apiVersion: superset.stackable.tech/v1alpha1
 kind: SupersetCluster
 metadata:


### PR DESCRIPTION
Fixes a regression - that probably results from #400 - by adding the correct secret key.