### PR TITLE
chore: Bump vector-aggretator to 0.55.0

### DIFF
--- a/stacks/_templates/vector-aggregator.yaml
+++ b/stacks/_templates/vector-aggregator.yaml
@@ -4,7 +4,7 @@ name: vector
 repo:
   name: vector
   url: https://helm.vector.dev
-version: 0.49.0 # app version 0.52.0
+version: 0.52.0 # app version 0.55.0
 options:
   commonLabels:
     stackable.tech/vendor: Stackable


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1486